### PR TITLE
refactor: zeroGL API cleanup — naming, type-safety, and named varying slots

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
       <br>
 
       <pre style="max-width:400px; margin: 0 auto; text-align: left;"><code>
-#define ZERGL_IMPLEMENTATION
+#define ZGL_IMPLEMENTATION
 #include "zerogl.h"
       </code></pre>
     </p>
@@ -63,7 +63,7 @@
     <section>
       <header><h2>Getting Started</h2></header>
       <pre><code>
-#define ZERGL_IMPLEMENTATION
+#define ZGL_IMPLEMENTATION
 #include "zerogl.h"
 
 // Use the stb_image library (not included with zeroGL) to write the result image to a file
@@ -75,14 +75,16 @@
 uint32_t pixels[WIDTH*HEIGHT];
 
 int main(void) {
-    zgl_canvas_t canvas = {WIDTH, HEIGHT, pixels, 0, NULL};
-    zgl_clear_depth_buffer(canvas);
+    zgl_framebuffer_t canvas = {
+        .color = { .pixels = pixels, .width = WIDTH, .height = HEIGHT },
+        .depth = NULL,
+    };
     zgl_render_fill(ZGL_COLOR_BLACK, canvas);
 
     zgl_render_triangle(400, 400, ZGL_COLOR_RED,
                         700, 400, ZGL_COLOR_GREEN,
                         700, 100, ZGL_COLOR_BLUE,
-                        canvas, 0);
+                        canvas);
 
     const char *file_path = "image.png";
     if (!stbi_write_png(file_path, WIDTH, HEIGHT, 4, pixels, sizeof(uint32_t)*WIDTH)) {
@@ -173,16 +175,16 @@ zgl_vec3_t       zgl_rotate(zgl_vec3_t v, zgl_quaternion_t q);
         </div>
         <div id="colors">
           <h3>Colors</h3>
-          <p>Colors are represented as a <code>uint32_t</code> in the pixel format of choice. The default format is <code>ZEROGL_PIXELFORMAT_RGBA8888</code>, so colors are represented using the form <code>0xRRGGBBAA</code> where <code>AA</code> is the alpha channel, <code>RR</code> is the red channel, <code>GG</code> is the green channel and <code>BB</code> is the blue channel. This are all the supported formats:</p>
+          <p>Colors are represented as a <code>uint32_t</code> in the pixel format of choice. The default format is <code>ZGL_PIXELFORMAT_RGBA8888</code>, so colors are represented using the form <code>0xRRGGBBAA</code> where <code>AA</code> is the alpha channel, <code>RR</code> is the red channel, <code>GG</code> is the green channel and <code>BB</code> is the blue channel. This are all the supported formats:</p>
           <pre><code>
-ZEROGL_PIXELFORMAT_RGBA8888
-ZEROGL_PIXELFORMAT_ARGB8888
-ZEROGL_PIXELFORMAT_BGRA8888
-ZEROGL_PIXELFORMAT_ABGR8888
+ZGL_PIXELFORMAT_RGBA8888
+ZGL_PIXELFORMAT_ARGB8888
+ZGL_PIXELFORMAT_BGRA8888
+ZGL_PIXELFORMAT_ABGR8888
           </code></pre>
           <p>The formats are compatible with the respective formats in SDL. The pixel format can be set by defining the following variable before importing zeroGL:</p>
           <pre><code>
-#define ZEROGL_PIXELFORMAT ZEROGL_PIXELFORMAT_RGBA8888
+#define ZGL_PIXELFORMAT ZGL_PIXELFORMAT_RGBA8888
           </code></pre>
         </div>
         <p>You can manipulate colors by using the following functions:</p>
@@ -219,36 +221,41 @@ zgl_camera_t zgl_camera(zgl_vec3_t position, zgl_vec3_t direction, zgl_vec3_t up
         </div>
         <div id="materials">
           <h3>Texture and Materials</h3>
-          <p>You can define a texture using the <code>zgl_canvas_t</code> struct (the same type used for the framebuffer). ZeroGL also provides a simple material system. Define a material using the <code>zgl_material_t</code> struct:</p>
+          <p>Textures are represented by the <code>zgl_texture_t</code> struct. Because a <code>zgl_framebuffer_t</code> stores its color attachment as a <code>zgl_texture_t</code>, anything rendered into a framebuffer can be sampled as a texture in a later pass without copying — just hand <code>fb.color</code> to any uniform that expects a texture. ZeroGL also provides a simple material system; define a material using the <code>zgl_material_t</code> struct:</p>
           <pre><code>
 typedef struct {
-    char*        name;
-    uint32_t     diffuseColor;
-    uint32_t     specularColor;
-    float        specularExponent;
-    zgl_canvas_t diffuseTexture;
-    zgl_canvas_t specularTexture;
+    char*         name;
+    uint32_t      ambientColor;
+    uint32_t      diffuseColor;
+    uint32_t      specularColor;
+    float         specularExponent;
+    zgl_texture_t ambientTexture;
+    zgl_texture_t diffuseTexture;
+    zgl_texture_t specularTexture;
 } zgl_material_t;
           </code></pre>
         </div>
         <div id="rendering">
           <h3>Rendering</h3>
-          <p>To draw, you need to create a <code>zgl_canvas_t</code> type and pass it to the drawing functions</p>
+          <p>To draw, create a <code>zgl_framebuffer_t</code> and pass it to the drawing functions. The framebuffer's color attachment is a <code>zgl_texture_t</code>, and the depth buffer is optional (pass <code>NULL</code> if you don't need depth testing).</p>
           <pre><code>
-zgl_canvas_t canvas = {WIDTH, HEIGHT, pixels, 0, NULL};
+zgl_framebuffer_t fb = {
+    .color = { .pixels = pixels, .width = WIDTH, .height = HEIGHT },
+    .depth = depthBuffer, // or NULL
+};
           </code></pre>
           <p>You can draw primitives such as lines, triangles and 3D objects using the following functions</p>
           <pre><code>
-void zgl_clear_depth_buffer(zgl_canvas_t canvas)
-void zgl_render_pixel(int x, int y, uint32_t color, zgl_canvas_t canvas)
-void zgl_render_fill(uint32_t color, zgl_canvas_t canvas)
-void zgl_render_line(int x0, int x1, int y0, int y1, uint32_t color, zgl_canvas_t canvas)
-void zgl_render_circle(int x, int y, int radius, uint32_t color, zgl_canvas_t canvas)
+void zgl_clear_depth_buffer(zgl_framebuffer_t fb)
+void zgl_render_pixel(int x, int y, float z, uint32_t color, zgl_framebuffer_t fb)
+void zgl_render_fill(uint32_t color, zgl_framebuffer_t fb)
+void zgl_render_line(int x0, int x1, int y0, int y1, uint32_t color, zgl_framebuffer_t fb)
+void zgl_render_circle(int x, int y, int radius, uint32_t color, zgl_framebuffer_t fb)
 void zgl_render_triangle(int x0, int y0, uint32_t color0,
                          int x1, int y1, uint32_t color1,
                          int x2, int y2, uint32_t color2,
-                         zgl_canvas_t canvas)
-void zgl_render_object3D(zgl_object3D_t* obj, void *uniform, zgl_camera_t cam, zgl_canvas_t c,
+                         zgl_framebuffer_t fb)
+void zgl_render_object3D(zgl_object3D_t* obj, void *uniform, zgl_camera_t cam, zgl_framebuffer_t fb,
                          zgl_vertex_shader_t vs, zgl_fragment_shader_t fs, uint16_t renderOptions)
           </code></pre>
         </div>
@@ -267,7 +274,7 @@ uint32_t             zgl_fragment_shader_t(zgl_shader_context_t* input, void* un
           <p>Draw with a single color, no lighting or textures</p>
           <pre><code>
 typedef struct {
-    zgl_mat4x4_t modelviewprojection;
+    zgl_mat4x4_t modelViewProjection;
 } zgl_basic_uniform_t;
 
 zgl_shader_context_t zgl_basic_vertex_shader(void* inputVertex, void* uniformData);
@@ -277,7 +284,7 @@ uint32_t zgl_basic_fragment_shader(const zgl_shader_context_t* input, void* unif
           <p>Draw with the color of the vertex, no lighting or textures</p>
           <pre><code>
 typedef struct {
-    zgl_mat4x4_t modelviewprojection;
+    zgl_mat4x4_t modelViewProjection;
 } zgl_colored_uniform_t;
 
 zgl_shader_context_t zgl_colored_vertex_shader(void* inputVertex, void* uniformData);
@@ -312,7 +319,7 @@ typedef struct {
 zgl_shader_context_t zgl_flat_vertex_shader(void* inputVertex, void* uniformData);
 uint32_t zgl_flat_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
           </code></pre>
-          <h5>Gourard Shader</h5>
+          <h5>Gouraud Shader</h5>
           <p>Compute the lighting at each vertex and interpolate the values at each pixel</p>
           <pre><code>
 typedef struct {
@@ -322,10 +329,10 @@ typedef struct {
     zgl_light_sources_t lightSources;
     int                 bilinearFiltering;
     zgl_material_t*     materials;
-} zgl_gourard_uniform_t;
+} zgl_gouraud_uniform_t;
 
-zgl_shader_context_t zgl_gourard_vertex_shader(void* inputVertex, void* uniformData);
-uint32_t zgl_gourard_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
+zgl_shader_context_t zgl_gouraud_vertex_shader(void* inputVertex, void* uniformData);
+uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
           </code></pre>
           <h5>Phong Shader</h5>
           <p>Compute the lighting per pixel</p>

--- a/main.c
+++ b/main.c
@@ -65,7 +65,7 @@ typedef struct game_state_t {
     SDL_Window*   window;
     SDL_Renderer* renderer;
     SDL_Texture*  texture;
-    zgl_canvas_t  canvas;
+    zgl_framebuffer_t canvas;
     uint32_t      backgroundColor;
     uint16_t      renderOptions;
     int           drawLights;
@@ -125,7 +125,7 @@ game_state_t* init() {
     vertices[1] = (zgl_vec3_t) {1, 0, 0};
     vertices[2] = (zgl_vec3_t) {0, 1, 0};
     triangles[0] = (zgl_triangle_t) {0, 2, 1, 0, 0, 0, 0, 0, 0, 0};
-    materials[0] = (zgl_material_t) {"RedMaterial", ZGL_COLOR_RED, ZGL_COLOR_RED, ZGL_COLOR_RED, 0.0f, (zgl_canvas_t) {NULL, 0, 0, 0, NULL}};
+    materials[0] = (zgl_material_t) {"RedMaterial", ZGL_COLOR_RED, ZGL_COLOR_RED, ZGL_COLOR_RED, 0.0f, (zgl_texture_t) {NULL, 0, 0}};
     meshes[0] = (zgl_mesh_t) {
         .name = "debug",
         .numVertices = 3,
@@ -190,12 +190,9 @@ game_state_t* init() {
         exit(-1);
     }
 
-    zgl_canvas_t canvas = {
-        .width = WIDTH,
-        .height = HEIGHT,
-        .hasDepthBuffer = 1,
-        .frameBuffer = frameBuffer,
-        .depthBuffer = depthBuffer
+    zgl_framebuffer_t canvas = {
+        .color = { .pixels = frameBuffer, .width = WIDTH, .height = HEIGHT },
+        .depth = depthBuffer,
     };
 
     game->running = 1;
@@ -750,7 +747,7 @@ void drawLights(game_state_t* game) {
 
 void render(game_state_t* game) {
     ZGL_DEBUG_PRINT("INFO: Rendering scene\n");
-    zgl_canvas_t canvas = game->canvas;
+    zgl_framebuffer_t canvas = game->canvas;
 
     zgl_clear_depth_buffer(canvas);
 
@@ -770,7 +767,7 @@ void render(game_state_t* game) {
     }
 
     ZGL_DEBUG_PRINT("INFO: Update backbuffer\n");
-    if (!SDL_UpdateTexture(game->texture, NULL, game->canvas.frameBuffer, PITCH)) {
+    if (!SDL_UpdateTexture(game->texture, NULL, game->canvas.color.pixels, PITCH)) {
         fprintf(stderr, "ERROR: Texture couldn't be updated: %s\n", SDL_GetError());
         exit(-1);
     }
@@ -791,8 +788,8 @@ void renderDebugUI(game_state_t* game) {
 #endif // DEBUGUI
 
 void destroy(game_state_t* game) {
-    free(game->canvas.frameBuffer);
-    free(game->canvas.depthBuffer);
+    free(game->canvas.color.pixels);
+    free(game->canvas.depth);
 
     // Free all triangles, vertices and materials from meshes
     for (int i = 0; i < game->numMeshes; i++) {

--- a/main.c
+++ b/main.c
@@ -214,7 +214,7 @@ game_state_t* init() {
     game->draw3DObjects = 1;
     game->bilinearFiltering = 0;
     game->shaderType = GOURAUD_SHADER;
-    game->renderOptions = ZGL_DIFFUSE_LIGHTING | ZGL_SPECULAR_LIGHTING | ZGL_BACKFACE_CULLING | ZGL_FUSTRUM_CULLING;
+    game->renderOptions = ZGL_DIFFUSE_LIGHTING | ZGL_SPECULAR_LIGHTING | ZGL_BACKFACE_CULLING | ZGL_FRUSTUM_CULLING;
     game->numMeshes = numMeshes;
     game->meshes = meshes;
     game->numObjects = numObjects;
@@ -511,9 +511,9 @@ void updateDebugUI(game_state_t *game) {
                 game->renderOptions = isBackfaceCulling ? game->renderOptions | ZGL_BACKFACE_CULLING : game->renderOptions & ~ZGL_BACKFACE_CULLING;
 
                 nk_layout_row_dynamic(ctx, row_size, 1);
-                nk_bool isFustrumCulling = game->renderOptions & ZGL_FUSTRUM_CULLING;
-                nk_checkbox_label(ctx, "Fustrum culling", &isFustrumCulling);
-                game->renderOptions = isFustrumCulling ? game->renderOptions | ZGL_FUSTRUM_CULLING : game->renderOptions & ~ZGL_FUSTRUM_CULLING;
+                nk_bool isFrustumCulling = game->renderOptions & ZGL_FRUSTUM_CULLING;
+                nk_checkbox_label(ctx, "Frustum culling", &isFrustumCulling);
+                game->renderOptions = isFrustumCulling ? game->renderOptions | ZGL_FRUSTUM_CULLING : game->renderOptions & ~ZGL_FRUSTUM_CULLING;
 
                 nk_layout_row_dynamic(ctx, row_size, 1);
                 nk_bool isBilinearFiltering = game->bilinearFiltering;
@@ -681,12 +681,12 @@ void drawObjects(game_state_t* game) {
         switch (game->shaderType) {
             case BASIC_SHADER:
                 zgl_basic_uniform_t basicUniformData = {
-                    .modelviewprojection = zgl_mul_mat(game->camera.viewProjMatrix, object.transform),
+                    .modelViewProjection = zgl_mul_mat(game->camera.viewProjMatrix, object.transform),
                 };
                 zgl_render_object3D(&object, &basicUniformData, game->camera, game->canvas, zgl_basic_vertex_shader, zgl_basic_fragment_shader, game->renderOptions);
             case COLORED_SHADER:
                 zgl_colored_uniform_t uniformData = {
-                    .modelviewprojection = zgl_mul_mat(game->camera.viewProjMatrix, object.transform),
+                    .modelViewProjection = zgl_mul_mat(game->camera.viewProjMatrix, object.transform),
                     .materials = object.mesh->materials
                 };
                 zgl_render_object3D(&object, &uniformData, game->camera, game->canvas, zgl_colored_vertex_shader, zgl_colored_fragment_shader, game->renderOptions);
@@ -713,7 +713,7 @@ void drawObjects(game_state_t* game) {
                 zgl_render_object3D(&object, &flatUniformData, game->camera, game->canvas, zgl_flat_vertex_shader, zgl_flat_fragment_shader, game->renderOptions);
                 break;
             case GOURAUD_SHADER:
-                zgl_gourard_uniform_t gourardUniformData = {
+                zgl_gouraud_uniform_t gouraudUniformData = {
                     .modelMatrix = object.transform,
                     .modelInvRotationMatrixTransposed = zgl_transpose(zgl_inverse(object.rotation)),
                     .viewProjectionMatrix = game->camera.viewProjMatrix,
@@ -721,7 +721,7 @@ void drawObjects(game_state_t* game) {
                     .bilinearFiltering = game->bilinearFiltering,
                     .materials = object.mesh->materials
                 };
-                zgl_render_object3D(&object, &gourardUniformData, game->camera, game->canvas, zgl_gourard_vertex_shader, zgl_gourard_fragment_shader, game->renderOptions);
+                zgl_render_object3D(&object, &gouraudUniformData, game->camera, game->canvas, zgl_gouraud_vertex_shader, zgl_gouraud_fragment_shader, game->renderOptions);
                 break;
             case PHONG_SHADER:
                 zgl_phong_uniform_t phongUniformData = {
@@ -742,7 +742,7 @@ void drawLights(game_state_t* game) {
     // Use basic shader to draw lights
     for (int i = 0; i < game->lightSources.numPointLights; i++) {
         zgl_basic_uniform_t uniformData = {
-            .modelviewprojection = zgl_mul_mat(game->camera.viewProjMatrix, game->pointLightObjects[i].transform),
+            .modelViewProjection = zgl_mul_mat(game->camera.viewProjMatrix, game->pointLightObjects[i].transform),
         };
         zgl_render_object3D(&game->pointLightObjects[i], &uniformData, game->camera, game->canvas, zgl_basic_vertex_shader, zgl_basic_fragment_shader, game->renderOptions);
     }

--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#define ZEROGL_IMPLEMENTATION
+#define ZGL_IMPLEMENTATION
 #include "zerogl.h"
 #include "objloader.h"
 
@@ -143,13 +143,13 @@ game_state_t* init() {
     meshes[5] = *loadObjFile("assets/woodcube/woodcube.obj", false);
     meshes[6] = *loadObjFile("assets/sphere.obj", false);
 
-    objects[0] = zgl_object(&meshes[0], (zgl_vec3_t) {0, 0, 0}, 1.0 , IDENTITY_M4x4);
-    objects[1] = zgl_object(&meshes[1], (zgl_vec3_t) {0, 0, 0}, 1.0, IDENTITY_M4x4);
-    objects[2] = zgl_object(&meshes[2], (zgl_vec3_t) {0, 0, 0}, 1.0, IDENTITY_M4x4);
-    objects[3] = zgl_object(&meshes[3], (zgl_vec3_t) {0, 0, 0}, 1.0, IDENTITY_M4x4);
-    objects[4] = zgl_object(&meshes[4], (zgl_vec3_t) {0, 0, 0}, 1.0, IDENTITY_M4x4);
-    objects[5] = zgl_object(&meshes[5], (zgl_vec3_t) {0, 0, 0}, 1.0, IDENTITY_M4x4);
-    objects[6] = zgl_object(&meshes[6], (zgl_vec3_t) {0, 0, 0}, 1.0, IDENTITY_M4x4);
+    objects[0] = zgl_object(&meshes[0], (zgl_vec3_t) {0, 0, 0}, 1.0 , ZGL_IDENTITY_M4);
+    objects[1] = zgl_object(&meshes[1], (zgl_vec3_t) {0, 0, 0}, 1.0, ZGL_IDENTITY_M4);
+    objects[2] = zgl_object(&meshes[2], (zgl_vec3_t) {0, 0, 0}, 1.0, ZGL_IDENTITY_M4);
+    objects[3] = zgl_object(&meshes[3], (zgl_vec3_t) {0, 0, 0}, 1.0, ZGL_IDENTITY_M4);
+    objects[4] = zgl_object(&meshes[4], (zgl_vec3_t) {0, 0, 0}, 1.0, ZGL_IDENTITY_M4);
+    objects[5] = zgl_object(&meshes[5], (zgl_vec3_t) {0, 0, 0}, 1.0, ZGL_IDENTITY_M4);
+    objects[6] = zgl_object(&meshes[6], (zgl_vec3_t) {0, 0, 0}, 1.0, ZGL_IDENTITY_M4);
 
     // Allocate object render toggles
     int* objectsRenderToggle = (int*) calloc(numObjects, sizeof(int));
@@ -179,7 +179,7 @@ game_state_t* init() {
     directionalLights[0] = (zgl_dir_light_t) {{0.0, 0.0, 0.0}, {0.0, -1.0, 1.0}};
     pointLights[0] = (zgl_point_light_t) {{0.9, 0.9, 0.9}, {-0.5, 1.5, -2.0}};
 
-    pointLightObjects[0] = zgl_object(&meshes[1], pointLights[0].position, 0.05, IDENTITY_M4x4);
+    pointLightObjects[0] = zgl_object(&meshes[1], pointLights[0].position, 0.05, ZGL_IDENTITY_M4);
 
     ZGL_DEBUG_PRINT("INFO: Initializing game state\n");
     uint32_t *frameBuffer = (uint32_t*) malloc(WIDTH * HEIGHT * sizeof(uint32_t));
@@ -426,7 +426,7 @@ void updateDebugUI(game_state_t *game) {
                             nk_property_float(ctx, "y", -10.0f, &game->lightSources.pointLights[i].position.y, 10.0f, 0.1f, 0.1f);
                             nk_layout_row_dynamic(ctx, row_size, 1);
                             nk_property_float(ctx, "z", -10.0f, &game->lightSources.pointLights[i].position.z, 10.0f, 0.1f, 0.1f);
-                            game->pointLightObjects[i] = zgl_object(&game->meshes[0], game->lightSources.pointLights[i].position, 0.05, IDENTITY_M4x4);
+                            game->pointLightObjects[i] = zgl_object(&game->meshes[0], game->lightSources.pointLights[i].position, 0.05, ZGL_IDENTITY_M4);
                             nk_group_end(ctx);
                         }
                     }

--- a/objloader.h
+++ b/objloader.h
@@ -12,10 +12,9 @@
 
 #include "zerogl.h"
 
-static inline zgl_canvas_t loadTexture(char* filename) {
+static inline zgl_texture_t loadTexture(char* filename) {
     ZGL_DEBUG_PRINT("DEBUG: Loading texture %s\n", filename);
-    zgl_canvas_t texture = {0};
-    texture.frameBuffer = NULL;
+    zgl_texture_t texture = {0};
 
     int channels;
     unsigned char* data = stbi_load(filename, &texture.width, &texture.height, &channels, 3);
@@ -24,8 +23,8 @@ static inline zgl_canvas_t loadTexture(char* filename) {
         exit(-1);
     }
 
-    texture.frameBuffer = (uint32_t*) malloc(texture.width * texture.height * sizeof(uint32_t));
-    if (texture.frameBuffer == NULL) {
+    texture.pixels = (uint32_t*) malloc(texture.width * texture.height * sizeof(uint32_t));
+    if (texture.pixels == NULL) {
         fprintf(stderr, "ERROR: Texture memory allocation failed.\n");
         exit(-1);
     }
@@ -35,7 +34,7 @@ static inline zgl_canvas_t loadTexture(char* filename) {
         uint8_t r = data[bufferIndex];
         uint8_t g = data[bufferIndex + 1];
         uint8_t b = data[bufferIndex + 2];
-        texture.frameBuffer[i] = zgl_color(r, g, b);
+        texture.pixels[i] = zgl_color(r, g, b);
     }
 
     stbi_image_free(data);
@@ -88,8 +87,8 @@ static inline zgl_material_t* loadMtlFile(const char* filename, int* numMaterial
                     // Deep copy diffuse texture to ambient texture if no ambient texture is present
                     materials[*numMaterials - 1].ambientTexture.height = materials[*numMaterials - 1].diffuseTexture.height;
                     materials[*numMaterials - 1].ambientTexture.width = materials[*numMaterials - 1].diffuseTexture.width;
-                    materials[*numMaterials - 1].ambientTexture.frameBuffer = (uint32_t*) malloc(materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
-                    memcpy(materials[*numMaterials - 1].ambientTexture.frameBuffer, materials[*numMaterials - 1].diffuseTexture.frameBuffer, materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
+                    materials[*numMaterials - 1].ambientTexture.pixels = (uint32_t*) malloc(materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
+                    memcpy(materials[*numMaterials - 1].ambientTexture.pixels, materials[*numMaterials - 1].diffuseTexture.pixels, materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
                 }
             }
 
@@ -106,8 +105,8 @@ static inline zgl_material_t* loadMtlFile(const char* filename, int* numMaterial
             materials[*numMaterials - 1].diffuseColor = zgl_color(255, 255, 255);
             materials[*numMaterials - 1].specularColor = zgl_color(0, 0, 0);
             materials[*numMaterials - 1].specularExponent = 10.0f;
-            materials[*numMaterials - 1].diffuseTexture = (zgl_canvas_t) {NULL, 0, 0,};
-            materials[*numMaterials - 1].specularTexture = (zgl_canvas_t) {NULL, 0, 0,};
+            materials[*numMaterials - 1].diffuseTexture = (zgl_texture_t) {NULL, 0, 0,};
+            materials[*numMaterials - 1].specularTexture = (zgl_texture_t) {NULL, 0, 0,};
         }
 
         if (line[0] == 'K' && line[1] == 'a') {
@@ -168,8 +167,8 @@ static inline zgl_material_t* loadMtlFile(const char* filename, int* numMaterial
         // Deep copy diffuse texture to ambient texture if no ambient texture is present
         materials[*numMaterials - 1].ambientTexture.height = materials[*numMaterials - 1].diffuseTexture.height;
         materials[*numMaterials - 1].ambientTexture.width = materials[*numMaterials - 1].diffuseTexture.width;
-        materials[*numMaterials - 1].ambientTexture.frameBuffer = (uint32_t*) malloc(materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
-        memcpy(materials[*numMaterials - 1].ambientTexture.frameBuffer, materials[*numMaterials - 1].diffuseTexture.frameBuffer, materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
+        materials[*numMaterials - 1].ambientTexture.pixels = (uint32_t*) malloc(materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
+        memcpy(materials[*numMaterials - 1].ambientTexture.pixels, materials[*numMaterials - 1].diffuseTexture.pixels, materials[*numMaterials - 1].diffuseTexture.width * materials[*numMaterials - 1].diffuseTexture.height * sizeof(uint32_t));
     }
 
     fclose(fp);

--- a/zerogl.h
+++ b/zerogl.h
@@ -1,5 +1,5 @@
-#ifndef ZEROGL_H
-#define ZEROGL_H
+#ifndef ZGL_H
+#define ZGL_H
 
 #include <assert.h>
 #include <float.h>
@@ -29,7 +29,7 @@ typedef struct {
   float data[4][4];
 } zgl_mat4x4_t;
 
-static const zgl_mat4x4_t IDENTITY_M4x4 = {{
+static const zgl_mat4x4_t ZGL_IDENTITY_M4 = {{
     {1.0, 0.0, 0.0, 0.0},
     {0.0, 1.0, 0.0, 0.0},
     {0.0, 0.0, 1.0, 0.0},
@@ -70,36 +70,36 @@ static inline zgl_vec3_t zgl_rotate(zgl_vec3_t v, zgl_quaternion_t q);
 /* Colors */
 
 // Pixel formats
-#define ZEROGL_PIXELFORMAT_RGBA8888 0
-#define ZEROGL_PIXELFORMAT_ARGB8888 1
-#define ZEROGL_PIXELFORMAT_BGRA8888 2
-#define ZEROGL_PIXELFORMAT_ABGR8888 3
+#define ZGL_PIXELFORMAT_RGBA8888 0
+#define ZGL_PIXELFORMAT_ARGB8888 1
+#define ZGL_PIXELFORMAT_BGRA8888 2
+#define ZGL_PIXELFORMAT_ABGR8888 3
 
 // Configure pixel format
-#ifndef ZEROGL_PIXELFORMAT
-#define ZEROGL_PIXELFORMAT ZEROGL_PIXELFORMAT_RGBA8888
-#endif // ZEROGL_PIXELFORMAT
+#ifndef ZGL_PIXELFORMAT
+#define ZGL_PIXELFORMAT ZGL_PIXELFORMAT_RGBA8888
+#endif // ZGL_PIXELFORMAT
 
 // Default colors
-#if  ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_RGBA8888
+#if  ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_RGBA8888
 static const uint32_t ZGL_COLOR_WHITE  = 0xFFFFFFFF;
 static const uint32_t ZGL_COLOR_BLACK  = 0x000000FF;
 static const uint32_t ZGL_COLOR_RED    = 0xFF0000FF;
 static const uint32_t ZGL_COLOR_GREEN  = 0x00FF00FF;
 static const uint32_t ZGL_COLOR_BLUE   = 0x0000FFFF;
-#elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_ARGB8888
+#elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_ARGB8888
 static const uint32_t ZGL_COLOR_WHITE  = 0x00FFFFFF;
 static const uint32_t ZGL_COLOR_BLACK  = 0x00000000;
 static const uint32_t ZGL_COLOR_RED    = 0x00FF0000;
 static const uint32_t ZGL_COLOR_GREEN  = 0x0000FF00;
 static const uint32_t ZGL_COLOR_BLUE   = 0x000000FF;
-#elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_BGRA8888
+#elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_BGRA8888
 static const uint32_t ZGL_COLOR_WHITE  = 0xFFFFFF00;
 static const uint32_t ZGL_COLOR_BLACK  = 0x00000000;
 static const uint32_t ZGL_COLOR_RED    = 0x0000FF00;
 static const uint32_t ZGL_COLOR_GREEN  = 0x00FF0000;
 static const uint32_t ZGL_COLOR_BLUE   = 0xFF000000;
-#elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_ABGR8888
+#elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_ABGR8888
 static const uint32_t ZGL_COLOR_WHITE  = 0x00FFFFFF;
 static const uint32_t ZGL_COLOR_BLACK  = 0x00000000;
 static const uint32_t ZGL_COLOR_RED    = 0x000000FF;
@@ -335,13 +335,13 @@ static inline void zgl_render_triangle(int x0, int y0, uint32_t color0,
 static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData, zgl_camera_t camera, zgl_canvas_t canvas,
                                        zgl_vertex_shader_t vertexShader, zgl_fragment_shader_t fragmentShader, uint16_t renderOptions);
 
-#endif // ZEROGL_H
+#endif // ZGL_H
 
 
-// Include implementation if the client sets ZEROGL_IMPLEMENTATION, but not twice
-#ifdef ZEROGL_IMPLEMENTATION
-#ifndef ZEROGL_IMPLEMENTATION_INCLUDED
-#define ZEROGL_IMPLEMENTATION_INCLUDED
+// Include implementation if the client sets ZGL_IMPLEMENTATION, but not twice
+#ifdef ZGL_IMPLEMENTATION
+#ifndef ZGL_IMPLEMENTATION_INCLUDED
+#define ZGL_IMPLEMENTATION_INCLUDED
 
 /* Utils */
 #define ZGL__PI 3.14159265358979323846264338327950288
@@ -564,7 +564,7 @@ static inline zgl_mat4x4_t zgl_inverse(zgl_mat4x4_t matrix) {
     det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
 
     if (det == 0)
-        return IDENTITY_M4x4;
+        return ZGL_IDENTITY_M4;
 
     det = 1.0 / det;
 
@@ -666,31 +666,31 @@ static inline zgl_vec3_t zgl_rotate(zgl_vec3_t v, zgl_quaternion_t q) {
 /* Colors */
 
 static inline uint32_t zgl_color(uint8_t r, uint8_t g, uint8_t b) {
-    #if  ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_RGBA8888
+    #if  ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_RGBA8888
     return 0x000000FF | ((uint32_t)r << 24) | ((uint32_t)g << 16) | ((uint32_t)b << 8);
-    #elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_ARGB8888
+    #elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_ARGB8888
     return 0xFF000000 | ((uint32_t)r << 16) | ((uint32_t)g << 8) |  (uint32_t)b;
-    #elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_BGRA8888
+    #elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_BGRA8888
     return 0x000000FF | ((uint32_t)b << 24) | ((uint32_t)g << 16) | ((uint32_t)r << 8);
-    #elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_ABGR8888
+    #elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_ABGR8888
     return 0xFF000000 | ((uint32_t)b << 16) | ((uint32_t)g << 8) |  (uint32_t)r;
     #endif
 }
 
 static inline void zgl_color_components(uint32_t c, uint8_t* r, uint8_t* g, uint8_t* b) {
-    #if  ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_RGBA8888
+    #if  ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_RGBA8888
     *r = (c & 0xFF000000) >> 24;
     *g = (c & 0x00FF0000) >> 16;
     *b = (c & 0x0000FF00) >> 8;
-    #elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_ARGB8888
+    #elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_ARGB8888
     *r = (c & 0x00FF0000) >> 16;
     *g = (c & 0x0000FF00) >> 8;
     *b = c & 0x000000FF;
-    #elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_BGRA8888
+    #elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_BGRA8888
     *r = (c & 0x0000FF00) >> 8;
     *g = (c & 0x00FF0000) >> 16;
     *b = (c & 0xFF000000) >> 24;
-    #elif ZEROGL_PIXELFORMAT == ZEROGL_PIXELFORMAT_ABGR8888
+    #elif ZGL_PIXELFORMAT == ZGL_PIXELFORMAT_ABGR8888
     *r = c & 0x000000FF;
     *g = (c & 0x0000FF00) >> 8;
     *b = (c & 0x00FF0000) >> 16;
@@ -1602,5 +1602,5 @@ static inline uint32_t zgl_phong_fragment_shader(const zgl_shader_context_t* inp
     return zgl_add_colors(specularColor, zgl_add_colors(ambientColor, diffuseColor));
 }
 
-#endif // ZEROGL_IMPLEMENTATION_INCLUDED
-#endif // ZEROGL_IMPLEMENTATION
+#endif // ZGL_IMPLEMENTATION_INCLUDED
+#endif // ZGL_IMPLEMENTATION

--- a/zerogl.h
+++ b/zerogl.h
@@ -255,6 +255,15 @@ typedef struct {
 typedef zgl_shader_context_t zgl_vertex_shader_t(void* inputVertex, void* uniformData);
 typedef uint32_t zgl_fragment_shader_t(const zgl_shader_context_t* input, void* uniformData);
 
+// Named typed views over zgl_shader_context_t::attributes/flatAttributes.
+// Each built-in shader defines a struct of plain floats and casts the float[]
+// storage to it, so vertex/fragment pairs can no longer drift on a numeric
+// index. The cast is routed through void* (every supported compiler aliases
+// a struct-of-floats over a float[]).
+#define ZGL_VARYING_FLOATS(T)              (sizeof(T) / sizeof(float))
+#define ZGL_VARYING_AS(T, ctx_attrs)       ((T*)       (void*)       (ctx_attrs))
+#define ZGL_VARYING_CONST_AS(T, ctx_attrs) ((const T*) (const void*) (ctx_attrs))
+
 typedef struct {
     zgl_mat4x4_t modelViewProjection;
 } zgl_basic_uniform_t;
@@ -267,6 +276,18 @@ typedef struct {
     zgl_material_t* materials;
 } zgl_colored_uniform_t;
 
+typedef struct {
+    float ambient_r,  ambient_g,  ambient_b;
+    float diffuse_r,  diffuse_g,  diffuse_b;
+    float specular_r, specular_g, specular_b;
+} zgl_colored_varying_t;
+
+// Used by zgl_render_triangle, which calls zgl_colored_fragment_shader with
+// only the ambient colour slots populated.
+typedef struct {
+    float r, g, b;
+} zgl_render_triangle_varying_t;
+
 static inline zgl_shader_context_t zgl_colored_vertex_shader(void* inputVertex, void* uniformData);
 static inline uint32_t zgl_colored_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
 
@@ -277,6 +298,19 @@ typedef struct {
     int                 bilinearFiltering;
     zgl_material_t*     materials;
 } zgl_unlit_uniform_t;
+
+typedef struct {
+    float u, v;
+} zgl_unlit_varying_t;
+
+typedef struct {
+    float nx, ny, nz;
+    float ambient_r,  ambient_g,  ambient_b;
+    float diffuse_r,  diffuse_g,  diffuse_b;
+    float specular_r, specular_g, specular_b;
+    float specular_exponent;
+    float material_index;
+} zgl_unlit_per_tri_t;
 
 static inline zgl_shader_context_t zgl_unlit_vertex_shader(void* inputVertex, void* uniformData);
 static inline uint32_t zgl_unlit_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
@@ -290,6 +324,22 @@ typedef struct {
     zgl_material_t*     materials;
 } zgl_flat_uniform_t;
 
+typedef struct {
+    float u, v;
+} zgl_flat_varying_t;
+
+typedef struct {
+    float nx, ny, nz;
+    float ambient_r,    ambient_g,    ambient_b;
+    float diffuse_r,    diffuse_g,    diffuse_b;
+    float specular_r,   specular_g,   specular_b;
+    float specular_exponent;
+    float light_amb_r,  light_amb_g,  light_amb_b;
+    float light_diff_r, light_diff_g, light_diff_b;
+    float light_spec_r, light_spec_g, light_spec_b;
+    float material_index;
+} zgl_flat_per_tri_t;
+
 static inline zgl_shader_context_t zgl_flat_vertex_shader(void* inputVertex, void* uniformData);
 static inline uint32_t zgl_flat_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
 
@@ -301,6 +351,22 @@ typedef struct {
     int                 bilinearFiltering;
     zgl_material_t*     materials;
 } zgl_gouraud_uniform_t;
+
+typedef struct {
+    float nx, ny, nz;
+    float u, v;
+    float ambient_r,    ambient_g,    ambient_b;
+    float diffuse_r,    diffuse_g,    diffuse_b;
+    float specular_r,   specular_g,   specular_b;
+    float specular_exponent;
+    float light_amb_r,  light_amb_g,  light_amb_b;
+    float light_diff_r, light_diff_g, light_diff_b;
+    float light_spec_r, light_spec_g, light_spec_b;
+} zgl_gouraud_varying_t;
+
+typedef struct {
+    float material_index;
+} zgl_gouraud_per_tri_t;
 
 static inline zgl_shader_context_t zgl_gouraud_vertex_shader(void* inputVertex, void* uniformData);
 static inline uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
@@ -314,8 +380,33 @@ typedef struct {
     zgl_material_t*     materials;
 } zgl_phong_uniform_t;
 
+typedef struct {
+    float nx, ny, nz;
+    float wx, wy, wz;
+    float u, v;
+    float ambient_r,  ambient_g,  ambient_b;
+    float diffuse_r,  diffuse_g,  diffuse_b;
+    float specular_r, specular_g, specular_b;
+    float specular_exponent;
+} zgl_phong_varying_t;
+
+typedef struct {
+    float material_index;
+} zgl_phong_per_tri_t;
+
 static inline zgl_shader_context_t zgl_phong_vertex_shader(void* inputVertex, void* uniformData);
 static inline uint32_t zgl_phong_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
+
+_Static_assert(ZGL_VARYING_FLOATS(zgl_colored_varying_t)         <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_colored_varying_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_render_triangle_varying_t) <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_render_triangle_varying_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_unlit_varying_t)           <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_unlit_varying_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_unlit_per_tri_t)           <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_unlit_per_tri_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_flat_varying_t)            <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_flat_varying_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_flat_per_tri_t)            <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_flat_per_tri_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_gouraud_varying_t)         <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_gouraud_varying_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_gouraud_per_tri_t)         <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_gouraud_per_tri_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_phong_varying_t)           <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_phong_varying_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
+_Static_assert(ZGL_VARYING_FLOATS(zgl_phong_per_tri_t)           <= ZGL_MAX_VERTEX_SHADER_ATTRIBUTES, "zgl_phong_per_tri_t exceeds ZGL_MAX_VERTEX_SHADER_ATTRIBUTES");
 
 /* Rendering */
 
@@ -1229,31 +1320,24 @@ static inline void zgl_render_triangle(int x0, int y0, uint32_t color0,
                                        int x2, int y2, uint32_t color2,
                                        zgl_framebuffer_t fb) {
     int area = zgl__edge_cross(x0, y0, x1, y1, x2, y2);
-    float r, g, b;
 
     zgl_shader_context_t shaderContext0 = {0};
     shaderContext0.position = (zgl_vec4_t) {x0, y0, 0, 1};
-    shaderContext0.numAttributes = 3;
-    zgl_color_to_floats(color0, &r, &g, &b);
-    shaderContext0.attributes[0] = r;
-    shaderContext0.attributes[1] = g;
-    shaderContext0.attributes[2] = b;
+    shaderContext0.numAttributes = ZGL_VARYING_FLOATS(zgl_render_triangle_varying_t);
+    zgl_render_triangle_varying_t* v0 = ZGL_VARYING_AS(zgl_render_triangle_varying_t, shaderContext0.attributes);
+    zgl_color_to_floats(color0, &v0->r, &v0->g, &v0->b);
 
     zgl_shader_context_t shaderContext1 = {0};
     shaderContext1.position = (zgl_vec4_t) {x1, y1, 0, 1};
-    shaderContext1.numAttributes = 3;
-    zgl_color_to_floats(color1, &r, &g, &b);
-    shaderContext1.attributes[0] = r;
-    shaderContext1.attributes[1] = g;
-    shaderContext1.attributes[2] = b;
+    shaderContext1.numAttributes = ZGL_VARYING_FLOATS(zgl_render_triangle_varying_t);
+    zgl_render_triangle_varying_t* v1 = ZGL_VARYING_AS(zgl_render_triangle_varying_t, shaderContext1.attributes);
+    zgl_color_to_floats(color1, &v1->r, &v1->g, &v1->b);
 
     zgl_shader_context_t shaderContext2 = {0};
     shaderContext2.position = (zgl_vec4_t) {x2, y2, 0, 1};
-    shaderContext2.numAttributes = 3;
-    zgl_color_to_floats(color2, &r, &g, &b);
-    shaderContext2.attributes[0] = r;
-    shaderContext2.attributes[1] = g;
-    shaderContext2.attributes[2] = b;
+    shaderContext2.numAttributes = ZGL_VARYING_FLOATS(zgl_render_triangle_varying_t);
+    zgl_render_triangle_varying_t* v2 = ZGL_VARYING_AS(zgl_render_triangle_varying_t, shaderContext2.attributes);
+    zgl_color_to_floats(color2, &v2->r, &v2->g, &v2->b);
 
     zgl_shader_context_t shaderContexts[3] = {shaderContext0, shaderContext1, shaderContext2};
     zgl__rasterize_triangle(x0, x1, x2, y0, y1, y2, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
@@ -1287,18 +1371,22 @@ static inline zgl_shader_context_t zgl_colored_vertex_shader(void* inputVertex, 
     zgl_colored_uniform_t* basicUniformData = (zgl_colored_uniform_t*) uniformData;
     zgl_vec4_t inputVertex4 = {inputVertexData->position.x, inputVertexData->position.y, inputVertexData->position.z, 1.0f};
     result.position = zgl_mul_mat_v4(basicUniformData->modelViewProjection, inputVertex4);
-    result.numAttributes = 9;
-    zgl_color_to_floats(basicUniformData->materials[inputVertexData->materialIndex].ambientColor, &result.attributes[0], &result.attributes[1], &result.attributes[2]);
-    zgl_color_to_floats(basicUniformData->materials[inputVertexData->materialIndex].diffuseColor, &result.attributes[3], &result.attributes[4], &result.attributes[5]);
-    zgl_color_to_floats(basicUniformData->materials[inputVertexData->materialIndex].specularColor, &result.attributes[6], &result.attributes[7], &result.attributes[8]);
+    result.numAttributes = ZGL_VARYING_FLOATS(zgl_colored_varying_t);
+
+    zgl_colored_varying_t* v = ZGL_VARYING_AS(zgl_colored_varying_t, result.attributes);
+    zgl_material_t mat = basicUniformData->materials[inputVertexData->materialIndex];
+    zgl_color_to_floats(mat.ambientColor,  &v->ambient_r,  &v->ambient_g,  &v->ambient_b);
+    zgl_color_to_floats(mat.diffuseColor,  &v->diffuse_r,  &v->diffuse_g,  &v->diffuse_b);
+    zgl_color_to_floats(mat.specularColor, &v->specular_r, &v->specular_g, &v->specular_b);
 
     return result;
 }
 
 static inline uint32_t zgl_colored_fragment_shader(const zgl_shader_context_t* input, void* uniformData) {
-    uint32_t ambientColor = zgl_color_from_floats(input->attributes[0], input->attributes[1], input->attributes[2]);
-    uint32_t diffuseColor = zgl_color_from_floats(input->attributes[3], input->attributes[4], input->attributes[5]);
-    uint32_t specularColor = zgl_color_from_floats(input->attributes[6], input->attributes[7], input->attributes[8]);
+    const zgl_colored_varying_t* v = ZGL_VARYING_CONST_AS(zgl_colored_varying_t, input->attributes);
+    uint32_t ambientColor  = zgl_color_from_floats(v->ambient_r,  v->ambient_g,  v->ambient_b);
+    uint32_t diffuseColor  = zgl_color_from_floats(v->diffuse_r,  v->diffuse_g,  v->diffuse_b);
+    uint32_t specularColor = zgl_color_from_floats(v->specular_r, v->specular_g, v->specular_b);
 
     return zgl_mul_colors(ambientColor, zgl_mul_colors(diffuseColor, specularColor));
 }
@@ -1314,54 +1402,50 @@ static inline zgl_shader_context_t zgl_unlit_vertex_shader(void* inputVertex, vo
     zgl_vec4_t worldSpaceVertex = zgl_mul_mat_v4(defaultUniformData->modelMatrix, inputVertex4); // Local to world space
     result.position = zgl_mul_mat_v4(defaultUniformData->viewProjectionMatrix, worldSpaceVertex); // World to clip space
 
+    result.numAttributes     = ZGL_VARYING_FLOATS(zgl_unlit_varying_t);
+    result.numFlatAttributes = ZGL_VARYING_FLOATS(zgl_unlit_per_tri_t);
 
-    result.numAttributes = 2;
-    result.attributes[0] = inputVertexData->textureCoord.x;   // u
-    result.attributes[1] = inputVertexData->textureCoord.y;   // v
+    zgl_unlit_varying_t* v = ZGL_VARYING_AS(zgl_unlit_varying_t, result.attributes);
+    zgl_unlit_per_tri_t* f = ZGL_VARYING_AS(zgl_unlit_per_tri_t, result.flatAttributes);
 
-    // Set other vertex attributes
-    result.numFlatAttributes = 14;
+    v->u = inputVertexData->textureCoord.x;
+    v->v = inputVertexData->textureCoord.y;
 
     zgl_vec3_t worldSpaceNormal = zgl_mul_mat_v3(defaultUniformData->modelInvRotationMatrixTransposed, inputVertexData->normal); // Local to world space
-    float invMagNormal = 1.0f / zgl_magnitude(worldSpaceNormal);
-    result.flatAttributes[0] = worldSpaceNormal.x;
-    result.flatAttributes[1] = worldSpaceNormal.y;
-    result.flatAttributes[2] = worldSpaceNormal.z;
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].ambientColor, &result.flatAttributes[3], &result.flatAttributes[4], &result.flatAttributes[5]);
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].diffuseColor, &result.flatAttributes[6], &result.flatAttributes[7], &result.flatAttributes[8]);
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].specularColor, &result.flatAttributes[9], &result.flatAttributes[10], &result.flatAttributes[11]);
-    result.flatAttributes[12] = defaultUniformData->materials[inputVertexData->materialIndex].specularExponent;
-
-    result.flatAttributes[13] = inputVertexData->materialIndex;
+    f->nx = worldSpaceNormal.x;
+    f->ny = worldSpaceNormal.y;
+    f->nz = worldSpaceNormal.z;
+    zgl_material_t mat = defaultUniformData->materials[inputVertexData->materialIndex];
+    zgl_color_to_floats(mat.ambientColor,  &f->ambient_r,  &f->ambient_g,  &f->ambient_b);
+    zgl_color_to_floats(mat.diffuseColor,  &f->diffuse_r,  &f->diffuse_g,  &f->diffuse_b);
+    zgl_color_to_floats(mat.specularColor, &f->specular_r, &f->specular_g, &f->specular_b);
+    f->specular_exponent = mat.specularExponent;
+    f->material_index    = (float) inputVertexData->materialIndex;
     return result;
 }
 
 static inline uint32_t zgl_unlit_fragment_shader(const zgl_shader_context_t* input, void* uniformData) {
     zgl_unlit_uniform_t* uniform = (zgl_unlit_uniform_t*) uniformData;
-    int materialIndex = input->flatAttributes[13];
+    const zgl_unlit_varying_t* v = ZGL_VARYING_CONST_AS(zgl_unlit_varying_t, input->attributes);
+    const zgl_unlit_per_tri_t* f = ZGL_VARYING_CONST_AS(zgl_unlit_per_tri_t, input->flatAttributes);
+    int materialIndex = (int) f->material_index;
 
     zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
-    uint32_t ambientColor = zgl_color_from_floats(input->flatAttributes[3], input->flatAttributes[4], input->flatAttributes[5]);
+    uint32_t ambientColor = zgl_color_from_floats(f->ambient_r, f->ambient_g, f->ambient_b);
     if (ambientTexture.width != 0 && ambientTexture.height != 0) {
-        float u = input->attributes[0];
-        float v = input->attributes[1];
-        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(u, v, ambientTexture, uniform->bilinearFiltering));
+        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(v->u, v->v, ambientTexture, uniform->bilinearFiltering));
     }
 
     zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
-    uint32_t diffuseColor = zgl_color_from_floats(input->flatAttributes[6], input->flatAttributes[7], input->flatAttributes[8]);
+    uint32_t diffuseColor = zgl_color_from_floats(f->diffuse_r, f->diffuse_g, f->diffuse_b);
     if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {
-        float u = input->attributes[0];
-        float v = input->attributes[1];
-        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(u, v, diffuseTexture, uniform->bilinearFiltering));
+        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(v->u, v->v, diffuseTexture, uniform->bilinearFiltering));
     }
 
     zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
-    uint32_t specularColor = zgl_color_from_floats(input->flatAttributes[9], input->flatAttributes[10], input->flatAttributes[11]);
+    uint32_t specularColor = zgl_color_from_floats(f->specular_r, f->specular_g, f->specular_b);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
-        float u = input->attributes[0];
-        float v = input->attributes[1];
-        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(u, v, specularTexture, uniform->bilinearFiltering));
+        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(v->u, v->v, specularTexture, uniform->bilinearFiltering));
     }
 
     return zgl_mul_colors(ambientColor, zgl_mul_colors(diffuseColor, specularColor));
@@ -1379,74 +1463,65 @@ static inline zgl_shader_context_t zgl_flat_vertex_shader(void* inputVertex, voi
     zgl_vec4_t worldSpaceVertex = zgl_mul_mat_v4(defaultUniformData->modelMatrix, inputVertex4); // Local to world space
     result.position = zgl_mul_mat_v4(defaultUniformData->viewProjectionMatrix, worldSpaceVertex); // World to clip space
 
-    result.numAttributes = 2;
-    result.attributes[0] = inputVertexData->textureCoord.x;   // u
-    result.attributes[1] = inputVertexData->textureCoord.y;   // v
+    result.numAttributes     = ZGL_VARYING_FLOATS(zgl_flat_varying_t);
+    result.numFlatAttributes = ZGL_VARYING_FLOATS(zgl_flat_per_tri_t);
 
-    // Set other vertex attributes
-    result.numFlatAttributes = 23;
+    zgl_flat_varying_t* v = ZGL_VARYING_AS(zgl_flat_varying_t, result.attributes);
+    zgl_flat_per_tri_t* f = ZGL_VARYING_AS(zgl_flat_per_tri_t, result.flatAttributes);
+
+    v->u = inputVertexData->textureCoord.x;
+    v->v = inputVertexData->textureCoord.y;
 
     zgl_vec3_t worldSpaceNormal = zgl_mul_mat_v3(defaultUniformData->modelInvRotationMatrixTransposed, inputVertexData->normal); // Local to world space
     float invMagNormal = 1.0f / zgl_magnitude(worldSpaceNormal);
-    result.flatAttributes[0] = worldSpaceNormal.x;
-    result.flatAttributes[1] = worldSpaceNormal.y;
-    result.flatAttributes[2] = worldSpaceNormal.z;
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].ambientColor, &result.flatAttributes[3], &result.flatAttributes[4], &result.flatAttributes[5]);
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].diffuseColor, &result.flatAttributes[6], &result.flatAttributes[7], &result.flatAttributes[8]);
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].specularColor, &result.flatAttributes[9], &result.flatAttributes[10], &result.flatAttributes[11]);
-    result.flatAttributes[12] = defaultUniformData->materials[inputVertexData->materialIndex].specularExponent;
+    f->nx = worldSpaceNormal.x;
+    f->ny = worldSpaceNormal.y;
+    f->nz = worldSpaceNormal.z;
+
+    zgl_material_t mat = defaultUniformData->materials[inputVertexData->materialIndex];
+    zgl_color_to_floats(mat.ambientColor,  &f->ambient_r,  &f->ambient_g,  &f->ambient_b);
+    zgl_color_to_floats(mat.diffuseColor,  &f->diffuse_r,  &f->diffuse_g,  &f->diffuse_b);
+    zgl_color_to_floats(mat.specularColor, &f->specular_r, &f->specular_g, &f->specular_b);
+    f->specular_exponent = mat.specularExponent;
 
     zgl_lighting_result_t lightResult = zgl_lighting((zgl_vec3_t) {worldSpaceVertex.x, worldSpaceVertex.y, worldSpaceVertex.z},
                                                      worldSpaceNormal, invMagNormal,
-                                                     defaultUniformData->materials[inputVertexData->materialIndex].specularExponent,
+                                                     mat.specularExponent,
                                                      defaultUniformData->lightSources, ZGL_DIFFUSE_LIGHTING | ZGL_SPECULAR_LIGHTING);
-    result.flatAttributes[13] = lightResult.ambient.x;
-    result.flatAttributes[14] = lightResult.ambient.y;
-    result.flatAttributes[15] = lightResult.ambient.z;
-    result.flatAttributes[16] = lightResult.diffuse.x;
-    result.flatAttributes[17] = lightResult.diffuse.y;
-    result.flatAttributes[18] = lightResult.diffuse.z;
-    result.flatAttributes[19] = lightResult.specular.x;
-    result.flatAttributes[20] = lightResult.specular.y;
-    result.flatAttributes[21] = lightResult.specular.z;
+    f->light_amb_r  = lightResult.ambient.x;  f->light_amb_g  = lightResult.ambient.y;  f->light_amb_b  = lightResult.ambient.z;
+    f->light_diff_r = lightResult.diffuse.x;  f->light_diff_g = lightResult.diffuse.y;  f->light_diff_b = lightResult.diffuse.z;
+    f->light_spec_r = lightResult.specular.x; f->light_spec_g = lightResult.specular.y; f->light_spec_b = lightResult.specular.z;
 
-    result.flatAttributes[22] = inputVertexData->materialIndex;
+    f->material_index = (float) inputVertexData->materialIndex;
     return result;
 }
 
 static inline uint32_t zgl_flat_fragment_shader(const zgl_shader_context_t* input, void* uniformData) {
     zgl_flat_uniform_t* uniform = (zgl_flat_uniform_t*) uniformData;
-    int materialIndex = input->flatAttributes[19];
+    const zgl_flat_varying_t* v = ZGL_VARYING_CONST_AS(zgl_flat_varying_t, input->attributes);
+    const zgl_flat_per_tri_t* f = ZGL_VARYING_CONST_AS(zgl_flat_per_tri_t, input->flatAttributes);
+    int materialIndex = (int) f->material_index;
 
     zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
-    uint32_t ambientColor = zgl_color_from_floats(input->flatAttributes[3], input->flatAttributes[4], input->flatAttributes[5]);
+    uint32_t ambientColor = zgl_color_from_floats(f->ambient_r, f->ambient_g, f->ambient_b);
     if (ambientTexture.width != 0 && ambientTexture.height != 0) {
-        float u = input->attributes[0];
-        float v = input->attributes[1];
-        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(u, v, ambientTexture, uniform->bilinearFiltering));
+        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(v->u, v->v, ambientTexture, uniform->bilinearFiltering));
     }
-    zgl_vec3_t ambientLight = {input->flatAttributes[13], input->flatAttributes[14], input->flatAttributes[15]};
-    ambientColor = zgl_mul_vec3_color(ambientLight, ambientColor);
+    ambientColor = zgl_mul_vec3_color((zgl_vec3_t){f->light_amb_r, f->light_amb_g, f->light_amb_b}, ambientColor);
 
     zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
-    uint32_t diffuseColor = zgl_color_from_floats(input->flatAttributes[6], input->flatAttributes[7], input->flatAttributes[8]);
+    uint32_t diffuseColor = zgl_color_from_floats(f->diffuse_r, f->diffuse_g, f->diffuse_b);
     if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {
-        float u = input->attributes[0];
-        float v = input->attributes[1];
-        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(u, v, diffuseTexture, uniform->bilinearFiltering));
+        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(v->u, v->v, diffuseTexture, uniform->bilinearFiltering));
     }
-    zgl_vec3_t diffuseLight = {input->flatAttributes[16], input->flatAttributes[17], input->flatAttributes[18]};
-    diffuseColor = zgl_mul_vec3_color(diffuseLight, diffuseColor);
+    diffuseColor = zgl_mul_vec3_color((zgl_vec3_t){f->light_diff_r, f->light_diff_g, f->light_diff_b}, diffuseColor);
 
     zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
-    uint32_t specularColor = zgl_color_from_floats(input->flatAttributes[9], input->flatAttributes[10], input->flatAttributes[11]);
+    uint32_t specularColor = zgl_color_from_floats(f->specular_r, f->specular_g, f->specular_b);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
-        float u = input->attributes[0];
-        float v = input->attributes[1];
-        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(u, v, specularTexture, uniform->bilinearFiltering));
+        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(v->u, v->v, specularTexture, uniform->bilinearFiltering));
     }
-    zgl_vec3_t specularLight = {input->flatAttributes[19], input->flatAttributes[20], input->flatAttributes[21]};
-    specularColor = zgl_mul_vec3_color(specularLight, specularColor);
+    specularColor = zgl_mul_vec3_color((zgl_vec3_t){f->light_spec_r, f->light_spec_g, f->light_spec_b}, specularColor);
 
     return zgl_add_colors(ambientColor, zgl_add_colors(diffuseColor, specularColor));
 }
@@ -1463,74 +1538,65 @@ static inline zgl_shader_context_t zgl_gouraud_vertex_shader(void* inputVertex, 
     zgl_vec4_t worldSpaceVertex = zgl_mul_mat_v4(defaultUniformData->modelMatrix, inputVertex4); // Local to world space
     result.position = zgl_mul_mat_v4(defaultUniformData->viewProjectionMatrix, worldSpaceVertex); // World to clip space
 
-    // Set other vertex attributes
-    result.numAttributes = 24;
+    result.numAttributes     = ZGL_VARYING_FLOATS(zgl_gouraud_varying_t);
+    result.numFlatAttributes = ZGL_VARYING_FLOATS(zgl_gouraud_per_tri_t);
+
+    zgl_gouraud_varying_t* v = ZGL_VARYING_AS(zgl_gouraud_varying_t, result.attributes);
+    zgl_gouraud_per_tri_t* f = ZGL_VARYING_AS(zgl_gouraud_per_tri_t, result.flatAttributes);
 
     zgl_vec3_t worldSpaceNormal = zgl_mul_mat_v3(defaultUniformData->modelInvRotationMatrixTransposed, inputVertexData->normal); // Local to world space
     float invMagNormal = 1.0f / zgl_magnitude(worldSpaceNormal);
-    result.attributes[0] = worldSpaceNormal.x;
-    result.attributes[1] = worldSpaceNormal.y;
-    result.attributes[2] = worldSpaceNormal.z;
-    result.attributes[3] = inputVertexData->textureCoord.x;   // u
-    result.attributes[4] = inputVertexData->textureCoord.y;   // v
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].ambientColor, &result.attributes[5], &result.attributes[6], &result.attributes[7]);
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].diffuseColor, &result.attributes[8], &result.attributes[9], &result.attributes[10]);
-    zgl_color_to_floats(defaultUniformData->materials[inputVertexData->materialIndex].specularColor, &result.attributes[11], &result.attributes[12], &result.attributes[13]);
-    result.attributes[14] = defaultUniformData->materials[inputVertexData->materialIndex].specularExponent;
+    v->nx = worldSpaceNormal.x;
+    v->ny = worldSpaceNormal.y;
+    v->nz = worldSpaceNormal.z;
+    v->u  = inputVertexData->textureCoord.x;
+    v->v  = inputVertexData->textureCoord.y;
+
+    zgl_material_t mat = defaultUniformData->materials[inputVertexData->materialIndex];
+    zgl_color_to_floats(mat.ambientColor,  &v->ambient_r,  &v->ambient_g,  &v->ambient_b);
+    zgl_color_to_floats(mat.diffuseColor,  &v->diffuse_r,  &v->diffuse_g,  &v->diffuse_b);
+    zgl_color_to_floats(mat.specularColor, &v->specular_r, &v->specular_g, &v->specular_b);
+    v->specular_exponent = mat.specularExponent;
 
     zgl_lighting_result_t lightResult = zgl_lighting((zgl_vec3_t) {worldSpaceVertex.x, worldSpaceVertex.y, worldSpaceVertex.z},
                                                      worldSpaceNormal, invMagNormal,
-                                                     defaultUniformData->materials[inputVertexData->materialIndex].specularExponent,
+                                                     mat.specularExponent,
                                                      defaultUniformData->lightSources, ZGL_DIFFUSE_LIGHTING | ZGL_SPECULAR_LIGHTING);
-    result.attributes[15] = lightResult.ambient.x;
-    result.attributes[16] = lightResult.ambient.y;
-    result.attributes[17] = lightResult.ambient.z;
-    result.attributes[18] = lightResult.diffuse.x;
-    result.attributes[19] = lightResult.diffuse.y;
-    result.attributes[20] = lightResult.diffuse.z;
-    result.attributes[21] = lightResult.specular.x;
-    result.attributes[22] = lightResult.specular.y;
-    result.attributes[23] = lightResult.specular.z;
+    v->light_amb_r  = lightResult.ambient.x;  v->light_amb_g  = lightResult.ambient.y;  v->light_amb_b  = lightResult.ambient.z;
+    v->light_diff_r = lightResult.diffuse.x;  v->light_diff_g = lightResult.diffuse.y;  v->light_diff_b = lightResult.diffuse.z;
+    v->light_spec_r = lightResult.specular.x; v->light_spec_g = lightResult.specular.y; v->light_spec_b = lightResult.specular.z;
 
-    result.numFlatAttributes = 1;
-    result.flatAttributes[0] = inputVertexData->materialIndex;
+    f->material_index = (float) inputVertexData->materialIndex;
     return result;
 }
 
 
 static inline uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* input, void* uniformData) {
     zgl_gouraud_uniform_t* uniform = (zgl_gouraud_uniform_t*) uniformData;
-    int materialIndex = input->flatAttributes[0];
+    const zgl_gouraud_varying_t* v = ZGL_VARYING_CONST_AS(zgl_gouraud_varying_t, input->attributes);
+    const zgl_gouraud_per_tri_t* f = ZGL_VARYING_CONST_AS(zgl_gouraud_per_tri_t, input->flatAttributes);
+    int materialIndex = (int) f->material_index;
 
     zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
-    uint32_t ambientColor = zgl_color_from_floats(input->attributes[5], input->attributes[6], input->attributes[7]);
+    uint32_t ambientColor = zgl_color_from_floats(v->ambient_r, v->ambient_g, v->ambient_b);
     if (ambientTexture.width != 0 && ambientTexture.height != 0) {
-        float u = input->attributes[3];
-        float v = input->attributes[4];
-        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(u, v, ambientTexture, uniform->bilinearFiltering));
+        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(v->u, v->v, ambientTexture, uniform->bilinearFiltering));
     }
-    zgl_vec3_t ambientLight = {input->attributes[15], input->attributes[16], input->attributes[17]};
-    ambientColor = zgl_mul_vec3_color(ambientLight, ambientColor);
+    ambientColor = zgl_mul_vec3_color((zgl_vec3_t){v->light_amb_r, v->light_amb_g, v->light_amb_b}, ambientColor);
 
     zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
-    uint32_t diffuseColor = zgl_color_from_floats(input->attributes[8], input->attributes[9], input->attributes[10]);
+    uint32_t diffuseColor = zgl_color_from_floats(v->diffuse_r, v->diffuse_g, v->diffuse_b);
     if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {
-        float u = input->attributes[3];
-        float v = input->attributes[4];
-        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(u, v, diffuseTexture, uniform->bilinearFiltering));
+        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(v->u, v->v, diffuseTexture, uniform->bilinearFiltering));
     }
-    zgl_vec3_t diffuseLight = {input->attributes[18], input->attributes[19], input->attributes[20]};
-    diffuseColor = zgl_mul_vec3_color(diffuseLight, diffuseColor);
+    diffuseColor = zgl_mul_vec3_color((zgl_vec3_t){v->light_diff_r, v->light_diff_g, v->light_diff_b}, diffuseColor);
 
     zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
-    uint32_t specularColor = zgl_color_from_floats(input->attributes[11], input->attributes[12], input->attributes[13]);
+    uint32_t specularColor = zgl_color_from_floats(v->specular_r, v->specular_g, v->specular_b);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
-        float u = input->attributes[3];
-        float v = input->attributes[4];
-        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(u, v, specularTexture, uniform->bilinearFiltering));
+        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(v->u, v->v, specularTexture, uniform->bilinearFiltering));
     }
-    zgl_vec3_t specularLight = {input->attributes[21], input->attributes[22], input->attributes[23]};
-    specularColor = zgl_mul_vec3_color(specularLight, specularColor);
+    specularColor = zgl_mul_vec3_color((zgl_vec3_t){v->light_spec_r, v->light_spec_g, v->light_spec_b}, specularColor);
 
     return zgl_add_colors(specularColor, zgl_add_colors(ambientColor, diffuseColor));
 }
@@ -1547,59 +1613,57 @@ static inline zgl_shader_context_t zgl_phong_vertex_shader(void* inputVertex, vo
     zgl_vec4_t worldSpaceVertex = zgl_mul_mat_v4(uniform->modelMatrix, inputVertex4); // Local to world space
     result.position = zgl_mul_mat_v4(uniform->viewProjectionMatrix, worldSpaceVertex); // World to clip space
 
-    // Set other vertex attributes
-    result.numAttributes = 18;
+    result.numAttributes     = ZGL_VARYING_FLOATS(zgl_phong_varying_t);
+    result.numFlatAttributes = ZGL_VARYING_FLOATS(zgl_phong_per_tri_t);
+
+    zgl_phong_varying_t* v = ZGL_VARYING_AS(zgl_phong_varying_t, result.attributes);
+    zgl_phong_per_tri_t* f = ZGL_VARYING_AS(zgl_phong_per_tri_t, result.flatAttributes);
+
     zgl_vec3_t worldSpaceNormal = zgl_mul_mat_v3(uniform->modelInvRotationMatrixTransposed, inputVertexData->normal); // Local to world space
-    result.attributes[0] = worldSpaceNormal.x;
-    result.attributes[1] = worldSpaceNormal.y;
-    result.attributes[2] = worldSpaceNormal.z;
-    result.attributes[3] = worldSpaceVertex.x;
-    result.attributes[4] = worldSpaceVertex.y;
-    result.attributes[5] = worldSpaceVertex.z;
-    result.attributes[6] = inputVertexData->textureCoord.x;    // u
-    result.attributes[7] = inputVertexData->textureCoord.y;    // v
+    v->nx = worldSpaceNormal.x; v->ny = worldSpaceNormal.y; v->nz = worldSpaceNormal.z;
+    v->wx = worldSpaceVertex.x; v->wy = worldSpaceVertex.y; v->wz = worldSpaceVertex.z;
+    v->u  = inputVertexData->textureCoord.x;
+    v->v  = inputVertexData->textureCoord.y;
 
-    zgl_color_to_floats(uniform->materials[inputVertexData->materialIndex].ambientColor, &result.attributes[8], &result.attributes[9], &result.attributes[10]);
-    zgl_color_to_floats(uniform->materials[inputVertexData->materialIndex].diffuseColor, &result.attributes[11], &result.attributes[12], &result.attributes[13]);
-    zgl_color_to_floats(uniform->materials[inputVertexData->materialIndex].specularColor, &result.attributes[14], &result.attributes[15], &result.attributes[16]);
-    result.attributes[17] = uniform->materials[inputVertexData->materialIndex].specularExponent;
+    zgl_material_t mat = uniform->materials[inputVertexData->materialIndex];
+    zgl_color_to_floats(mat.ambientColor,  &v->ambient_r,  &v->ambient_g,  &v->ambient_b);
+    zgl_color_to_floats(mat.diffuseColor,  &v->diffuse_r,  &v->diffuse_g,  &v->diffuse_b);
+    zgl_color_to_floats(mat.specularColor, &v->specular_r, &v->specular_g, &v->specular_b);
+    v->specular_exponent = mat.specularExponent;
 
-    result.numFlatAttributes = 1;
-    result.flatAttributes[0] = inputVertexData->materialIndex;
+    f->material_index = (float) inputVertexData->materialIndex;
     return result;
 }
 
 static inline uint32_t zgl_phong_fragment_shader(const zgl_shader_context_t* input, void* uniformData) {
     zgl_phong_uniform_t* uniform = (zgl_phong_uniform_t*) uniformData;
+    const zgl_phong_varying_t* v = ZGL_VARYING_CONST_AS(zgl_phong_varying_t, input->attributes);
+    const zgl_phong_per_tri_t* f = ZGL_VARYING_CONST_AS(zgl_phong_per_tri_t, input->flatAttributes);
 
-    zgl_vec3_t normal = {input->attributes[0], input->attributes[1], input->attributes[2]};
-    zgl_vec3_t position = {input->attributes[3], input->attributes[4], input->attributes[5]};
-    float specularExponent = input->attributes[17];
+    zgl_vec3_t normal   = {v->nx, v->ny, v->nz};
+    zgl_vec3_t position = {v->wx, v->wy, v->wz};
     float invMagNormal = 1.0f / zgl_magnitude(normal);
-    zgl_lighting_result_t lightingResult = zgl_lighting(position, normal, invMagNormal, specularExponent, uniform->lightSources, ZGL_DIFFUSE_LIGHTING | ZGL_SPECULAR_LIGHTING);
-    int materialIndex = input->flatAttributes[0];
-    
-    float u = input->attributes[6];
-    float v = input->attributes[7];
+    zgl_lighting_result_t lightingResult = zgl_lighting(position, normal, invMagNormal, v->specular_exponent, uniform->lightSources, ZGL_DIFFUSE_LIGHTING | ZGL_SPECULAR_LIGHTING);
+    int materialIndex = (int) f->material_index;
 
     zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
-    uint32_t ambientColor = zgl_color_from_floats(input->attributes[8], input->attributes[9], input->attributes[10]);
-    if (ambientTexture.width != 0 && ambientTexture.height != 0) {    
-        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(u, v, ambientTexture, uniform->bilinearFiltering));
+    uint32_t ambientColor = zgl_color_from_floats(v->ambient_r, v->ambient_g, v->ambient_b);
+    if (ambientTexture.width != 0 && ambientTexture.height != 0) {
+        ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(v->u, v->v, ambientTexture, uniform->bilinearFiltering));
     }
     ambientColor = zgl_mul_vec3_color(lightingResult.ambient, ambientColor);
-    
+
     zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
-    uint32_t diffuseColor = zgl_color_from_floats(input->attributes[11], input->attributes[12], input->attributes[13]);
-    if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {    
-        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(u, v, diffuseTexture, uniform->bilinearFiltering));
+    uint32_t diffuseColor = zgl_color_from_floats(v->diffuse_r, v->diffuse_g, v->diffuse_b);
+    if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {
+        diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(v->u, v->v, diffuseTexture, uniform->bilinearFiltering));
     }
     diffuseColor = zgl_mul_vec3_color(lightingResult.diffuse, diffuseColor);
 
     zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
-    uint32_t specularColor = zgl_color_from_floats(input->attributes[14], input->attributes[15], input->attributes[16]);
+    uint32_t specularColor = zgl_color_from_floats(v->specular_r, v->specular_g, v->specular_b);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
-        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(u, v, specularTexture, uniform->bilinearFiltering));
+        specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(v->u, v->v, specularTexture, uniform->bilinearFiltering));
     }
     specularColor = zgl_mul_vec3_color(lightingResult.specular, specularColor);
 

--- a/zerogl.h
+++ b/zerogl.h
@@ -218,7 +218,7 @@ typedef struct {
     zgl_mat4x4_t viewMatrix;       // View matrix
     zgl_mat4x4_t projectionMatrix; // Projection matrix
     zgl_mat4x4_t viewProjMatrix;   // View * Projection matrix
-    zgl_vec4_t   fustrumPlanes[6]; // View frustum planes
+    zgl_vec4_t   frustumPlanes[6]; // View frustum planes
     float        movementSpeed;
     float        turningSpeed;
 } zgl_camera_t;
@@ -253,14 +253,14 @@ typedef zgl_shader_context_t zgl_vertex_shader_t(void* inputVertex, void* unifor
 typedef uint32_t zgl_fragment_shader_t(const zgl_shader_context_t* input, void* uniformData);
 
 typedef struct {
-    zgl_mat4x4_t modelviewprojection;
+    zgl_mat4x4_t modelViewProjection;
 } zgl_basic_uniform_t;
 
 static inline zgl_shader_context_t zgl_basic_vertex_shader(void* inputVertex, void* uniformData);
 static inline uint32_t zgl_basic_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
 
 typedef struct {
-    zgl_mat4x4_t    modelviewprojection;
+    zgl_mat4x4_t    modelViewProjection;
     zgl_material_t* materials;
 } zgl_colored_uniform_t;
 
@@ -297,10 +297,10 @@ typedef struct {
     zgl_light_sources_t lightSources;
     int                 bilinearFiltering;
     zgl_material_t*     materials;
-} zgl_gourard_uniform_t;
+} zgl_gouraud_uniform_t;
 
-static inline zgl_shader_context_t zgl_gourard_vertex_shader(void* inputVertex, void* uniformData);
-static inline uint32_t zgl_gourard_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
+static inline zgl_shader_context_t zgl_gouraud_vertex_shader(void* inputVertex, void* uniformData);
+static inline uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* input, void* uniformData);
 
 typedef struct {
     zgl_mat4x4_t        modelMatrix;
@@ -320,7 +320,7 @@ static inline uint32_t zgl_phong_fragment_shader(const zgl_shader_context_t* inp
 #define ZGL_DIFFUSE_LIGHTING (1 << 0)
 #define ZGL_SPECULAR_LIGHTING (1 << 1)
 #define ZGL_BACKFACE_CULLING (1 << 2)
-#define ZGL_FUSTRUM_CULLING (1 << 3)
+#define ZGL_FRUSTUM_CULLING (1 << 3)
 #define ZGL_BILINEAR_FILTERING (1 << 4) // TODO: Implement bilinear filtering
 
 static inline void zgl_clear_depth_buffer(zgl_canvas_t canvas);
@@ -934,13 +934,13 @@ static inline zgl_camera_t zgl_camera(zgl_vec3_t position, zgl_vec3_t direction,
         .viewMatrix = viewMatrix,
         .projectionMatrix = projectionMatrix,
         .viewProjMatrix = viewProjMatrix,
-        .fustrumPlanes = {leftPlane, rightPlane, bottomPlane, topPlane, nearPlane, farPlane},
+        .frustumPlanes = {leftPlane, rightPlane, bottomPlane, topPlane, nearPlane, farPlane},
         .movementSpeed = movementSpeed,
         .turningSpeed = turningSpeed
     };
 }
 
-static inline int zgl__tri_in_fustrum(zgl_vec4_t v1, zgl_vec4_t v2, zgl_vec4_t v3) {
+static inline int zgl__tri_in_frustum(zgl_vec4_t v1, zgl_vec4_t v2, zgl_vec4_t v3) {
     // Using NDC coordinates
     if (v1.x < -1 && v2.x < -1 && v3.x < -1) return 0;
     if (v1.x >  1 && v2.x >  1 && v3.x >  1) return 0;
@@ -1119,14 +1119,14 @@ static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData
                                        zgl_vertex_shader_t vertexShader, zgl_fragment_shader_t fragmentShader, uint16_t renderOptions) {
     zgl_mesh_t* mesh = object->mesh;
 
-    // Don't draw if the object is fully outside the camera fustrum
-    if (renderOptions & ZGL_FUSTRUM_CULLING) {
+    // Don't draw if the object is fully outside the camera frustum
+    if (renderOptions & ZGL_FRUSTUM_CULLING) {
         for (int p = 0; p < 6; p++) {
-            zgl_vec4_t plane = camera.fustrumPlanes[p];
+            zgl_vec4_t plane = camera.frustumPlanes[p];
             int isInside = 1;
             zgl_vec4_t center = zgl_mul_mat_v4(object->transform, (zgl_vec4_t) {mesh->center.x, mesh->center.y, mesh->center.z, 1});
             if (zgl_dot_v4(plane, center) < -(object->scale * mesh->boundsRadius)) {
-                ZGL_DEBUG_PRINT("DEBUG: Culled object using fustrum culling {plane %d}\n", p);
+                ZGL_DEBUG_PRINT("DEBUG: Culled object using frustum culling {plane %d}\n", p);
                 return;
             }
         }
@@ -1204,10 +1204,10 @@ static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData
             continue;
         }
 
-        if ((renderOptions & ZGL_FUSTRUM_CULLING) && !zgl__tri_in_fustrum(vertexShaderOutput[0].position,
+        if ((renderOptions & ZGL_FRUSTUM_CULLING) && !zgl__tri_in_frustum(vertexShaderOutput[0].position,
                                                                           vertexShaderOutput[1].position,
                                                                           vertexShaderOutput[2].position)) {
-            ZGL_DEBUG_PRINT("DEBUG: Culled triangle using fustrum culling\n");
+            ZGL_DEBUG_PRINT("DEBUG: Culled triangle using frustum culling\n");
             continue;
         }
 
@@ -1266,7 +1266,7 @@ static inline zgl_shader_context_t zgl_basic_vertex_shader(void* inputVertex, vo
     zgl_shader_context_t result = {0};
     zgl_basic_uniform_t* basicUniformData = (zgl_basic_uniform_t*) uniformData;
     zgl_vec4_t inputVertex4 = {inputVertexData->position.x, inputVertexData->position.y, inputVertexData->position.z, 1.0f};
-    result.position = zgl_mul_mat_v4(basicUniformData->modelviewprojection, inputVertex4);
+    result.position = zgl_mul_mat_v4(basicUniformData->modelViewProjection, inputVertex4);
     return result;
 }
 
@@ -1282,7 +1282,7 @@ static inline zgl_shader_context_t zgl_colored_vertex_shader(void* inputVertex, 
     zgl_shader_context_t result = {0};
     zgl_colored_uniform_t* basicUniformData = (zgl_colored_uniform_t*) uniformData;
     zgl_vec4_t inputVertex4 = {inputVertexData->position.x, inputVertexData->position.y, inputVertexData->position.z, 1.0f};
-    result.position = zgl_mul_mat_v4(basicUniformData->modelviewprojection, inputVertex4);
+    result.position = zgl_mul_mat_v4(basicUniformData->modelViewProjection, inputVertex4);
     result.numAttributes = 9;
     zgl_color_to_floats(basicUniformData->materials[inputVertexData->materialIndex].ambientColor, &result.attributes[0], &result.attributes[1], &result.attributes[2]);
     zgl_color_to_floats(basicUniformData->materials[inputVertexData->materialIndex].diffuseColor, &result.attributes[3], &result.attributes[4], &result.attributes[5]);
@@ -1451,10 +1451,10 @@ static inline uint32_t zgl_flat_fragment_shader(const zgl_shader_context_t* inpu
 /* Gouraud shading */
 // Compute the lighting at each vertex and interpolate the values at each fragment
 
-static inline zgl_shader_context_t zgl_gourard_vertex_shader(void* inputVertex, void* uniformData) {
+static inline zgl_shader_context_t zgl_gouraud_vertex_shader(void* inputVertex, void* uniformData) {
     zgl_vertex_input_t* inputVertexData = (zgl_vertex_input_t*) inputVertex;
     zgl_shader_context_t result = {0};
-    zgl_gourard_uniform_t* defaultUniformData = (zgl_gourard_uniform_t*) uniformData;
+    zgl_gouraud_uniform_t* defaultUniformData = (zgl_gouraud_uniform_t*) uniformData;
     zgl_vec4_t inputVertex4 = {inputVertexData->position.x, inputVertexData->position.y, inputVertexData->position.z, 1.0f};
     zgl_vec4_t worldSpaceVertex = zgl_mul_mat_v4(defaultUniformData->modelMatrix, inputVertex4); // Local to world space
     result.position = zgl_mul_mat_v4(defaultUniformData->viewProjectionMatrix, worldSpaceVertex); // World to clip space
@@ -1494,8 +1494,8 @@ static inline zgl_shader_context_t zgl_gourard_vertex_shader(void* inputVertex, 
 }
 
 
-static inline uint32_t zgl_gourard_fragment_shader(const zgl_shader_context_t* input, void* uniformData) {
-    zgl_gourard_uniform_t* uniform = (zgl_gourard_uniform_t*) uniformData;
+static inline uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* input, void* uniformData) {
+    zgl_gouraud_uniform_t* uniform = (zgl_gouraud_uniform_t*) uniformData;
     int materialIndex = input->flatAttributes[0];
 
     zgl_canvas_t ambientTexture = uniform->materials[materialIndex].ambientTexture;

--- a/zerogl.h
+++ b/zerogl.h
@@ -117,12 +117,15 @@ static inline void zgl_color_to_floats(uint32_t color, float* r, float* g, float
 
 /* 3D Objects */
 typedef struct {
-    uint32_t* frameBuffer;
+    uint32_t* pixels;
     int       width;
     int       height;
-    int       hasDepthBuffer;
-    float*    depthBuffer;
-} zgl_canvas_t;
+} zgl_texture_t;
+
+typedef struct {
+    zgl_texture_t color;   // color attachment; also usable as a zgl_texture_t
+    float*        depth;   // optional; NULL means no depth buffer
+} zgl_framebuffer_t;
 
 typedef struct {
   int     v0, v1, v2;
@@ -137,9 +140,9 @@ typedef struct {
     uint32_t     diffuseColor;
     uint32_t     specularColor;
     float        specularExponent;
-    zgl_canvas_t ambientTexture;
-    zgl_canvas_t diffuseTexture;
-    zgl_canvas_t specularTexture;
+    zgl_texture_t ambientTexture;
+    zgl_texture_t diffuseTexture;
+    zgl_texture_t specularTexture;
 } zgl_material_t;
 
 typedef struct {
@@ -170,7 +173,7 @@ typedef struct {
 static inline zgl_object3D_t zgl_object(zgl_mesh_t *mesh, zgl_vec3_t translation, float scale, zgl_mat4x4_t rotation);
 static inline zgl_vec3_t zgl_mesh_center(zgl_vec3_t* vertices, int numVertices);
 static inline float zgl_mesh_bound_radius(zgl_vec3_t* vertices, int numVertices, zgl_vec3_t center);
-uint32_t zgl_sample_texture(float u, float v, zgl_canvas_t texture, int bilinearFiltering);
+uint32_t zgl_sample_texture(float u, float v, zgl_texture_t texture, int bilinearFiltering);
 
 /* Lighting */
 typedef struct {
@@ -323,16 +326,16 @@ static inline uint32_t zgl_phong_fragment_shader(const zgl_shader_context_t* inp
 #define ZGL_FRUSTUM_CULLING (1 << 3)
 #define ZGL_BILINEAR_FILTERING (1 << 4) // TODO: Implement bilinear filtering
 
-static inline void zgl_clear_depth_buffer(zgl_canvas_t canvas);
-static inline void zgl_render_pixel(int i, int j, float z, uint32_t color, zgl_canvas_t canvas);
-static inline void zgl_render_fill(uint32_t color, zgl_canvas_t canvas);
-static inline void zgl_render_line(int x0, int x1, int y0, int y1, uint32_t color, zgl_canvas_t canvas);
-static inline void zgl_render_circle(int x, int y, int r, uint32_t color, zgl_canvas_t canvas);
+static inline void zgl_clear_depth_buffer(zgl_framebuffer_t fb);
+static inline void zgl_render_pixel(int i, int j, float z, uint32_t color, zgl_framebuffer_t fb);
+static inline void zgl_render_fill(uint32_t color, zgl_framebuffer_t fb);
+static inline void zgl_render_line(int x0, int x1, int y0, int y1, uint32_t color, zgl_framebuffer_t fb);
+static inline void zgl_render_circle(int x, int y, int r, uint32_t color, zgl_framebuffer_t fb);
 static inline void zgl_render_triangle(int x0, int y0, uint32_t color0,
                                        int x1, int y1, uint32_t color1,
                                        int x2, int y2, uint32_t color2,
-                                       zgl_canvas_t canvas);
-static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData, zgl_camera_t camera, zgl_canvas_t canvas,
+                                       zgl_framebuffer_t fb);
+static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData, zgl_camera_t camera, zgl_framebuffer_t fb,
                                        zgl_vertex_shader_t vertexShader, zgl_fragment_shader_t fragmentShader, uint16_t renderOptions);
 
 #endif // ZGL_H
@@ -769,7 +772,7 @@ static inline float zgl_mesh_bound_radius(zgl_vec3_t* vertices, int numVertices,
     return result;
 }
 
-uint32_t zgl_sample_texture(float u, float v, zgl_canvas_t texture, int bilinearFiltering) {
+uint32_t zgl_sample_texture(float u, float v, zgl_texture_t texture, int bilinearFiltering) {
     int textureWidth = texture.width;
     int textureHeight = texture.height;
     float tex_u = ZGL__MIN(fabs(u * textureWidth), textureWidth - 1);
@@ -782,15 +785,15 @@ uint32_t zgl_sample_texture(float u, float v, zgl_canvas_t texture, int bilinear
         float ratio_v = tex_v - floor_v;
         int next_u = ZGL__MIN(floor_u + 1, textureWidth - 1);
         int next_v = ZGL__MIN(floor_v + 1, textureHeight - 1);
-        uint32_t color00 = texture.frameBuffer[floor_v * textureWidth + floor_u];
-        uint32_t color10 = texture.frameBuffer[floor_v * textureWidth + next_u];
-        uint32_t color01 = texture.frameBuffer[next_v * textureWidth + floor_u];
-        uint32_t color11 = texture.frameBuffer[next_v * textureWidth + next_u];
+        uint32_t color00 = texture.pixels[floor_v * textureWidth + floor_u];
+        uint32_t color10 = texture.pixels[floor_v * textureWidth + next_u];
+        uint32_t color01 = texture.pixels[next_v * textureWidth + floor_u];
+        uint32_t color11 = texture.pixels[next_v * textureWidth + next_u];
         uint32_t color0 = zgl_add_colors(zgl_mul_scalar_color(1.0f - ratio_u, color00), zgl_mul_scalar_color(ratio_u, color10));
         uint32_t color1 = zgl_add_colors(zgl_mul_scalar_color(1.0f - ratio_u, color01), zgl_mul_scalar_color(ratio_u, color11));
         return zgl_add_colors(zgl_mul_scalar_color(1.0f - ratio_v, color0), zgl_mul_scalar_color(ratio_v, color1));
     } else {
-        return texture.frameBuffer[floor_v * textureWidth + floor_u];
+        return texture.pixels[floor_v * textureWidth + floor_u];
     }
 }
 
@@ -961,27 +964,28 @@ static inline int zgl__edge_cross(int ax, int ay, int bx, int by, int px, int py
   return abx * apy - aby * apx;
 }
 
-static inline void zgl_clear_depth_buffer(zgl_canvas_t canvas) {
-    for (int i = 0; i < canvas.width * canvas.height; i++) {
-        canvas.depthBuffer[i] = FLT_MAX;
+static inline void zgl_clear_depth_buffer(zgl_framebuffer_t fb) {
+    if (fb.depth == NULL) return;
+    for (int i = 0; i < fb.color.width * fb.color.height; i++) {
+        fb.depth[i] = FLT_MAX;
     }
 }
 
-static inline void zgl_render_pixel(int i, int j, float z, uint32_t color, zgl_canvas_t canvas) {
-    if ((i >= 0) && (i < canvas.width) && (j >= 0) && (j < canvas.height)) {
-        int position = j * canvas.width + i;
-        canvas.frameBuffer[position] = color;
-        canvas.depthBuffer[position] = z;
+static inline void zgl_render_pixel(int i, int j, float z, uint32_t color, zgl_framebuffer_t fb) {
+    if ((i >= 0) && (i < fb.color.width) && (j >= 0) && (j < fb.color.height)) {
+        int position = j * fb.color.width + i;
+        fb.color.pixels[position] = color;
+        if (fb.depth) fb.depth[position] = z;
     }
 }
 
-static inline void zgl_render_fill(uint32_t color, zgl_canvas_t canvas) {
-    for (int i = 0; i < canvas.width * canvas.height; i++) {
-        canvas.frameBuffer[i] = color;
+static inline void zgl_render_fill(uint32_t color, zgl_framebuffer_t fb) {
+    for (int i = 0; i < fb.color.width * fb.color.height; i++) {
+        fb.color.pixels[i] = color;
     }
 }
 
-static inline void zgl_render_line(int x0, int x1, int y0, int y1, uint32_t color, zgl_canvas_t canvas) {
+static inline void zgl_render_line(int x0, int x1, int y0, int y1, uint32_t color, zgl_framebuffer_t fb) {
     int delta_x = (x1 - x0);
     int delta_y = (y1 - y0);
     int longest_side_length = (abs(delta_x) >= abs(delta_y)) ? abs(delta_x) : abs(delta_y);
@@ -990,13 +994,13 @@ static inline void zgl_render_line(int x0, int x1, int y0, int y1, uint32_t colo
     float current_x = x0;
     float current_y = y0;
     for (int i = 0; i <= longest_side_length; i++) {
-        zgl_render_pixel(round(current_x), round(current_y), 0.0, color, canvas);
+        zgl_render_pixel(round(current_x), round(current_y), 0.0, color, fb);
         current_x += x_inc;
         current_y += y_inc;
     }
 }
 
-static inline void zgl_render_circle(int x, int y, int r, uint32_t color, zgl_canvas_t canvas) {
+static inline void zgl_render_circle(int x, int y, int r, uint32_t color, zgl_framebuffer_t fb) {
     int x1 = x - r;
     int x2 = x + r;
     int y1 = y - r;
@@ -1006,7 +1010,7 @@ static inline void zgl_render_circle(int x, int y, int r, uint32_t color, zgl_ca
             int dx = i - x;
             int dy = j - y;
             if (dx * dx + dy * dy <= r * r) {
-                zgl_render_pixel(i, j, 0.0, color, canvas);
+                zgl_render_pixel(i, j, 0.0, color, fb);
             }
         }
     }
@@ -1022,11 +1026,11 @@ static inline void zgl__rasterize_triangle(int x0, int x1, int x2,
                                            int area,
                                            zgl_shader_context_t vertexShaderOutput[3],
                                            zgl_fragment_shader_t fragmentShader, void* uniformData,
-                                           zgl_canvas_t canvas) {
+                                           zgl_framebuffer_t fb) {
     int x_min = ZGL__MAX(ZGL__MIN(ZGL__MIN(x0, x1), x2), 0);
-    int x_max = ZGL__MIN(ZGL__MAX(ZGL__MAX(x0, x1), x2), canvas.width - 1);
+    int x_max = ZGL__MIN(ZGL__MAX(ZGL__MAX(x0, x1), x2), fb.color.width - 1);
     int y_min = ZGL__MAX(ZGL__MIN(ZGL__MIN(y0, y1), y2), 0);
-    int y_max = ZGL__MIN(ZGL__MAX(ZGL__MAX(y0, y1), y2), canvas.height - 1);
+    int y_max = ZGL__MIN(ZGL__MAX(ZGL__MAX(y0, y1), y2), fb.color.height - 1);
 
     int delta_w0_col = (y1 - y2);
     int delta_w1_col = (y2 - y0);
@@ -1066,7 +1070,7 @@ static inline void zgl__rasterize_triangle(int x0, int x1, int x2,
                 float z = alpha * z0 + beta * z1 + gamma * z2;
 
                 // Depth test
-                if (z < canvas.depthBuffer[y * canvas.width + x]) {
+                if (!fb.depth || z < fb.depth[y * fb.color.width + x]) {
                     // Compute fragment input attributes from the outputs of the vertex shader
                     zgl_shader_context_t fragmentShaderInput = {0};
 
@@ -1097,7 +1101,7 @@ static inline void zgl__rasterize_triangle(int x0, int x1, int x2,
                     }
 
                     uint32_t color = fragmentShader(&fragmentShaderInput, uniformData);
-                    zgl_render_pixel(x, y, z, color, canvas); // TODO: Avoid scissor test in zgl_render_pixel
+                    zgl_render_pixel(x, y, z, color, fb); // TODO: Avoid scissor test in zgl_render_pixel
                 }
             }
 
@@ -1115,7 +1119,7 @@ static inline void zgl__rasterize_triangle(int x0, int x1, int x2,
     }
 }
 
-static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData, zgl_camera_t camera, zgl_canvas_t canvas,
+static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData, zgl_camera_t camera, zgl_framebuffer_t fb,
                                        zgl_vertex_shader_t vertexShader, zgl_fragment_shader_t fragmentShader, uint16_t renderOptions) {
     zgl_mesh_t* mesh = object->mesh;
 
@@ -1190,8 +1194,8 @@ static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData
             vertexShaderOutput[v].position.w = 1.0f;
 
             // Viewport transform (NDC -> screen space)
-            xs[v] = (vertexShaderOutput[v].position.x + 1.0f) * canvas.width / 2.0f;
-            ys[v] = (1.0f - vertexShaderOutput[v].position.y) * canvas.height / 2.0f;
+            xs[v] = (vertexShaderOutput[v].position.x + 1.0f) * fb.color.width / 2.0f;
+            ys[v] = (1.0f - vertexShaderOutput[v].position.y) * fb.color.height / 2.0f;
             zs[v] = vertexShaderOutput[v].position.z; // For z-buffer
             invws[v] = invw; // Store 1/w to avoid divisions later when performing perspective correct interpolation
         }
@@ -1216,14 +1220,14 @@ static inline void zgl_render_object3D(zgl_object3D_t* object, void *uniformData
                                 ys[0], ys[1], ys[2],
                                 zs[0], zs[1], zs[2],
                                 invws[0], invws[1], invws[2],
-                                area, vertexShaderOutput, fragmentShader, uniformData, canvas);
+                                area, vertexShaderOutput, fragmentShader, uniformData, fb);
     }
 }
 
 static inline void zgl_render_triangle(int x0, int y0, uint32_t color0,
                                        int x1, int y1, uint32_t color1,
                                        int x2, int y2, uint32_t color2,
-                                       zgl_canvas_t canvas) {
+                                       zgl_framebuffer_t fb) {
     int area = zgl__edge_cross(x0, y0, x1, y1, x2, y2);
     float r, g, b;
 
@@ -1253,7 +1257,7 @@ static inline void zgl_render_triangle(int x0, int y0, uint32_t color0,
 
     zgl_shader_context_t shaderContexts[3] = {shaderContext0, shaderContext1, shaderContext2};
     zgl__rasterize_triangle(x0, x1, x2, y0, y1, y2, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
-                            area, shaderContexts, zgl_colored_fragment_shader, NULL, canvas);
+                            area, shaderContexts, zgl_colored_fragment_shader, NULL, fb);
 }
 
 /* Shaders */
@@ -1336,7 +1340,7 @@ static inline uint32_t zgl_unlit_fragment_shader(const zgl_shader_context_t* inp
     zgl_unlit_uniform_t* uniform = (zgl_unlit_uniform_t*) uniformData;
     int materialIndex = input->flatAttributes[13];
 
-    zgl_canvas_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
+    zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
     uint32_t ambientColor = zgl_color_from_floats(input->flatAttributes[3], input->flatAttributes[4], input->flatAttributes[5]);
     if (ambientTexture.width != 0 && ambientTexture.height != 0) {
         float u = input->attributes[0];
@@ -1344,7 +1348,7 @@ static inline uint32_t zgl_unlit_fragment_shader(const zgl_shader_context_t* inp
         ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(u, v, ambientTexture, uniform->bilinearFiltering));
     }
 
-    zgl_canvas_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
+    zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
     uint32_t diffuseColor = zgl_color_from_floats(input->flatAttributes[6], input->flatAttributes[7], input->flatAttributes[8]);
     if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {
         float u = input->attributes[0];
@@ -1352,7 +1356,7 @@ static inline uint32_t zgl_unlit_fragment_shader(const zgl_shader_context_t* inp
         diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(u, v, diffuseTexture, uniform->bilinearFiltering));
     }
 
-    zgl_canvas_t specularTexture = uniform->materials[materialIndex].specularTexture;
+    zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
     uint32_t specularColor = zgl_color_from_floats(input->flatAttributes[9], input->flatAttributes[10], input->flatAttributes[11]);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
         float u = input->attributes[0];
@@ -1414,7 +1418,7 @@ static inline uint32_t zgl_flat_fragment_shader(const zgl_shader_context_t* inpu
     zgl_flat_uniform_t* uniform = (zgl_flat_uniform_t*) uniformData;
     int materialIndex = input->flatAttributes[19];
 
-    zgl_canvas_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
+    zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
     uint32_t ambientColor = zgl_color_from_floats(input->flatAttributes[3], input->flatAttributes[4], input->flatAttributes[5]);
     if (ambientTexture.width != 0 && ambientTexture.height != 0) {
         float u = input->attributes[0];
@@ -1424,7 +1428,7 @@ static inline uint32_t zgl_flat_fragment_shader(const zgl_shader_context_t* inpu
     zgl_vec3_t ambientLight = {input->flatAttributes[13], input->flatAttributes[14], input->flatAttributes[15]};
     ambientColor = zgl_mul_vec3_color(ambientLight, ambientColor);
 
-    zgl_canvas_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
+    zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
     uint32_t diffuseColor = zgl_color_from_floats(input->flatAttributes[6], input->flatAttributes[7], input->flatAttributes[8]);
     if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {
         float u = input->attributes[0];
@@ -1434,7 +1438,7 @@ static inline uint32_t zgl_flat_fragment_shader(const zgl_shader_context_t* inpu
     zgl_vec3_t diffuseLight = {input->flatAttributes[16], input->flatAttributes[17], input->flatAttributes[18]};
     diffuseColor = zgl_mul_vec3_color(diffuseLight, diffuseColor);
 
-    zgl_canvas_t specularTexture = uniform->materials[materialIndex].specularTexture;
+    zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
     uint32_t specularColor = zgl_color_from_floats(input->flatAttributes[9], input->flatAttributes[10], input->flatAttributes[11]);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
         float u = input->attributes[0];
@@ -1498,7 +1502,7 @@ static inline uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* i
     zgl_gouraud_uniform_t* uniform = (zgl_gouraud_uniform_t*) uniformData;
     int materialIndex = input->flatAttributes[0];
 
-    zgl_canvas_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
+    zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
     uint32_t ambientColor = zgl_color_from_floats(input->attributes[5], input->attributes[6], input->attributes[7]);
     if (ambientTexture.width != 0 && ambientTexture.height != 0) {
         float u = input->attributes[3];
@@ -1508,7 +1512,7 @@ static inline uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* i
     zgl_vec3_t ambientLight = {input->attributes[15], input->attributes[16], input->attributes[17]};
     ambientColor = zgl_mul_vec3_color(ambientLight, ambientColor);
 
-    zgl_canvas_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
+    zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
     uint32_t diffuseColor = zgl_color_from_floats(input->attributes[8], input->attributes[9], input->attributes[10]);
     if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {
         float u = input->attributes[3];
@@ -1518,7 +1522,7 @@ static inline uint32_t zgl_gouraud_fragment_shader(const zgl_shader_context_t* i
     zgl_vec3_t diffuseLight = {input->attributes[18], input->attributes[19], input->attributes[20]};
     diffuseColor = zgl_mul_vec3_color(diffuseLight, diffuseColor);
 
-    zgl_canvas_t specularTexture = uniform->materials[materialIndex].specularTexture;
+    zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
     uint32_t specularColor = zgl_color_from_floats(input->attributes[11], input->attributes[12], input->attributes[13]);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
         float u = input->attributes[3];
@@ -1578,21 +1582,21 @@ static inline uint32_t zgl_phong_fragment_shader(const zgl_shader_context_t* inp
     float u = input->attributes[6];
     float v = input->attributes[7];
 
-    zgl_canvas_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
+    zgl_texture_t ambientTexture = uniform->materials[materialIndex].ambientTexture;
     uint32_t ambientColor = zgl_color_from_floats(input->attributes[8], input->attributes[9], input->attributes[10]);
     if (ambientTexture.width != 0 && ambientTexture.height != 0) {    
         ambientColor = zgl_mul_colors(ambientColor, zgl_sample_texture(u, v, ambientTexture, uniform->bilinearFiltering));
     }
     ambientColor = zgl_mul_vec3_color(lightingResult.ambient, ambientColor);
     
-    zgl_canvas_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
+    zgl_texture_t diffuseTexture = uniform->materials[materialIndex].diffuseTexture;
     uint32_t diffuseColor = zgl_color_from_floats(input->attributes[11], input->attributes[12], input->attributes[13]);
     if (diffuseTexture.width != 0 && diffuseTexture.height != 0) {    
         diffuseColor = zgl_mul_colors(diffuseColor, zgl_sample_texture(u, v, diffuseTexture, uniform->bilinearFiltering));
     }
     diffuseColor = zgl_mul_vec3_color(lightingResult.diffuse, diffuseColor);
 
-    zgl_canvas_t specularTexture = uniform->materials[materialIndex].specularTexture;
+    zgl_texture_t specularTexture = uniform->materials[materialIndex].specularTexture;
     uint32_t specularColor = zgl_color_from_floats(input->attributes[14], input->attributes[15], input->attributes[16]);
     if (specularTexture.width != 0 && specularTexture.height != 0) {
         specularColor = zgl_mul_colors(specularColor, zgl_sample_texture(u, v, specularTexture, uniform->bilinearFiltering));


### PR DESCRIPTION
## Summary

Five-commit cleanup pass over the zeroGL public API. Each commit is a
standalone refactor — no behaviour changes intended outside one drive-by
bug fix called out below.

| Commit | What |
|---|---|
| `b14a352` | Unify `ZEROGL_*` and `IDENTITY_M4x4` prefixes under `ZGL_*` |
| `09f61db` | Fix `gourard` → `gouraud`, `fustrum` → `frustum`, `modelviewprojection` casing |
| `7eda9b4` | Split overloaded `zgl_canvas_t` into `zgl_framebuffer_t` (write target) and `zgl_texture_t` (read source) |
| `4edc891` | Update `docs/index.html` to match renamed identifiers |
| `45452c0` | Replace numeric attribute indices in built-in shaders with named varying structs |

## Why named varying slots

Built-in shaders previously exchanged data with the rasterizer through
`float attributes[N]` / `flatAttributes[N]` indexed by hard-coded
integer literals. Vertex and fragment shaders had to keep their indices
in lockstep by hand — a mismatch silently sampled garbage. Each shader
now defines a struct of named float fields (`zgl_*_varying_t` and
`zgl_*_per_tri_t`) that aliases the same underlying float storage:

```c
zgl_gouraud_varying_t* v = ZGL_VARYING_AS(zgl_gouraud_varying_t, result.attributes);
v->u = inputVertexData->textureCoord.x;
v->v = inputVertexData->textureCoord.y;
```

Reading and writing now go through the same name, so the compiler
catches drift. `_Static_assert`s guard each struct against
`ZGL_MAX_VERTEX_SHADER_ATTRIBUTES`. The on-disk float layout, the
rasterizer's interpolation contract, and `zgl_shader_context_t` itself
are all unchanged — `main.c` needed no edits.

## Drive-by bug fix

`zgl_flat_fragment_shader` previously read `materialIndex` from
`flatAttributes[19]` (which the vertex shader writes as
`lightResult.specular.x`); the vertex shader stores `materialIndex` at
`[22]`. With the named struct both sides reference
`f->material_index`, so the bug disappears. Effect: textures on the
flat shader now use the correct per-vertex material instead of always
material 0.

## Test plan

- [x] Compiles clean: `gcc -O2 -Wall -Wextra -Wstrict-aliasing -c zerogl.h` with `ZGL_IMPLEMENTATION` defined (5 pre-existing warnings unrelated to this PR remain)
- [x] `_Static_assert` block confirms every varying/per-tri struct fits in `ZGL_MAX_VERTEX_SHADER_ATTRIBUTES`
- [x] No remaining numeric-literal `attributes[N]` / `flatAttributes[N]` references outside the rasterizer's interpolation loop
- [x] Field offsets in each varying/per-tri struct verified by inspection to match the prior numeric indices (so output is bit-identical, except for the flat-shader bug fix)
- [ ] **Visual smoke test in the SDL3 demo** — SDL3 isn't installable in this environment; reviewer should `make` and click through each shading mode (basic/colored/unlit/flat/gouraud/phong) on the engineer mesh
- [ ] Confirm flat-shader bug fix renders correctly on a multi-material model

https://claude.ai/code/session_01CP9dEivCMc4rP9kUe8p5bR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CP9dEivCMc4rP9kUe8p5bR)_